### PR TITLE
New Feature: init fn for moudle and init params for app

### DIFF
--- a/packages/core/src/graphql-app.ts
+++ b/packages/core/src/graphql-app.ts
@@ -10,18 +10,25 @@ export interface NonModules {
   resolvers?: any;
 }
 
+export interface InitParams {
+  [key: string]: any;
+}
+
 export interface GraphQLAppOptions {
   modules: GraphQLModule[];
   nonModules?: NonModules;
   communicationBridge?: CommunicationBridge;
+  initParams?: InitParams | (() => InitParams) | (() => Promise<InitParams>);
 }
 
 export class GraphQLApp {
   private readonly _modules: GraphQLModule[];
   private readonly _schema: GraphQLSchema;
   private readonly _resolvers: IResolvers;
+  private _initModulesValue: { [key: string]: any; } = {};
+  private _resolvedInitParams: { [key: string]: any; } = {};
 
-  constructor(options: GraphQLAppOptions) {
+  constructor(private options: GraphQLAppOptions) {
     const allTypes = options.modules.map<string>(m => m.typeDefs).filter(t => t);
     const nonModules = options.nonModules || {};
 
@@ -34,6 +41,40 @@ export class GraphQLApp {
       ]),
       resolvers: this._resolvers,
     });
+  }
+
+  async init(): Promise<void> {
+    let params: InitParams = null;
+    const builtResult = {};
+
+    if (this.options && this.options.initParams) {
+      if (typeof this.options.initParams === 'object') {
+        params = this.options.initParams;
+      } else if (typeof this.options.initParams === 'function') {
+        params = await this.options.initParams();
+      }
+    }
+
+    this._resolvedInitParams = params;
+
+    const relevantModules: GraphQLModule[] = this._modules.filter(f => f.onInit);
+    let module;
+
+    try {
+      for (module of relevantModules) {
+        const appendToContext: any = await module.onInit(params);
+
+        if (appendToContext && typeof appendToContext === 'object') {
+          Object.assign(builtResult, { [module.name]: appendToContext });
+        }
+      }
+    } catch (e) {
+      logger.error(`Unable to initialized module! Module "${module.name}" failed: `, e);
+
+      throw e;
+    }
+
+    this._initModulesValue = builtResult;
   }
 
   get schema(): GraphQLSchema {
@@ -57,7 +98,7 @@ export class GraphQLApp {
 
   async buildContext(networkRequest?: any): Promise<IGraphQLContext> {
     const relevantContextModules: GraphQLModule[] = this._modules.filter(f => f.contextBuilder);
-    const builtResult = {};
+    const builtResult = { ...this._initModulesValue, initParams: this._resolvedInitParams || {} };
     const result = this.buildImplementationsObject();
 
     let module;

--- a/packages/core/src/graphql-module.ts
+++ b/packages/core/src/graphql-module.ts
@@ -6,6 +6,7 @@ export interface IGraphQLContext {
 }
 
 export type BuildContextFn = (networkContext?: any) => IGraphQLContext;
+export type InitFn = (params: any) => any;
 
 export type Context<Impl = any> = {
   [P in keyof Impl]: Impl[P];
@@ -17,12 +18,14 @@ export interface GraphQLModuleOptions<Impl> {
   resolvers?: IResolvers;
   implementation?: Impl;
   contextBuilder?: BuildContextFn;
+  onInit?: InitFn;
 }
 
 export class GraphQLModule<Impl = any> {
   private readonly _name: string;
   private readonly _typeDefs: string;
   private readonly _resolvers: IResolvers = {};
+  private readonly _onInit: InitFn = null;
   private _impl: Impl = null;
   private _contextBuilder: BuildContextFn = null;
 
@@ -32,6 +35,11 @@ export class GraphQLModule<Impl = any> {
     this._resolvers = options.resolvers || {};
     this._impl = options.implementation || null;
     this._contextBuilder = options.contextBuilder || null;
+    this._onInit = options.onInit || null;
+  }
+
+  get onInit(): InitFn {
+    return this._onInit;
   }
 
   get name(): string {

--- a/packages/core/tests/graphql-module.spec.ts
+++ b/packages/core/tests/graphql-module.spec.ts
@@ -73,4 +73,11 @@ describe('GraphQLModule', () => {
 
     expect(module.contextBuilder).toBe(mockCallback);
   });
+
+  it('should set the init fn correctly', () => {
+    const mockCallback = jest.fn();
+    const module = new GraphQLModule({ onInit: mockCallback, name: 'test', typeDefs: TEST_TYPES });
+
+    expect(module.onInit).toBe(mockCallback);
+  });
 });


### PR DESCRIPTION
The idea is that you can pass arguments (such as config, settings, etc..) to the app, and it will trigger `onInit` function of each module with the init object. 
 
This is a nice way to pass things such as config, db connection... 

Also, the return value of the `onInit` is appended to the context as `[module.name]: VALUE` 