### PR TITLE
Refactor sonar package options

### DIFF
--- a/packages/sonar/tests/file-scanner.spec.ts
+++ b/packages/sonar/tests/file-scanner.spec.ts
@@ -1,8 +1,8 @@
 import {loadResolversFiles, loadSchemaFiles} from '../src';
 
-function testSchemaDir(path, expectedResult, note, extensions?) {
+function testSchemaDir(path, expectedResult, note, extensions?: string[]) {
   it(`should return the correct schema results for path: ${path} (${note})`, () => {
-    const result = loadSchemaFiles(path, extensions);
+    const result = loadSchemaFiles(path, extensions ? { extensions } : {});
 
     expect(result.length).toBe(expectedResult.length);
     expect(result.map(stripWhitespaces)).toEqual(expectedResult.map(stripWhitespaces));
@@ -11,7 +11,7 @@ function testSchemaDir(path, expectedResult, note, extensions?) {
 
 function testResolversDir(path, expectedResult, note, extensions?) {
   it(`should return the correct resolvers results for path: ${path} (${note})`, () => {
-    const result = loadResolversFiles(path, extensions);
+    const result = loadResolversFiles(path, extensions ? { extensions } : {});
 
     expect(result.length).toBe(expectedResult.length);
     expect(result).toEqual(expectedResult);


### PR DESCRIPTION
Now it's possible to force `require`, provide `glob` options, and provide a custom extensions for scanner. 
These features are required if we want to run it with Meteor, because it has it's own `require` method, and we can't use `process.cwd()` because it's pointing to an internal Meteor directory (use `process.env.PWD` instead. 

Also, it's useful if you are using Webpack (or Meteor compiler) for `.graphql` files and compiles them to `Document` instead of raw string. 