### PR TITLE
[core] expose server config without getters

### DIFF
--- a/examples/basic/src/server.ts
+++ b/examples/basic/src/server.ts
@@ -2,7 +2,8 @@ import { GraphQLApp } from '@graphql-modules/core';
 import { ApolloServer } from 'apollo-server';
 
 export async function run(app: GraphQLApp) {
-  const server = new ApolloServer(app);
+  const serverConfig = app.generateServerConfig();
+  const server = new ApolloServer(serverConfig);
 
   const { url } = await server.listen();
 

--- a/examples/di/src/server.ts
+++ b/examples/di/src/server.ts
@@ -2,7 +2,8 @@ import { GraphQLApp } from '@graphql-modules/core';
 import { ApolloServer } from 'apollo-server';
 
 export async function run(app: GraphQLApp) {
-  const server = new ApolloServer(app);
+  const serverConfig = app.generateServerConfig();
+  const server = new ApolloServer(serverConfig);
 
   const { url } = await server.listen();
 

--- a/packages/core/src/graphql-app.ts
+++ b/packages/core/src/graphql-app.ts
@@ -39,6 +39,14 @@ export interface GraphQLAppOptions {
   providers?: Provider[];
 }
 
+export type ContextFn<Context> = (reqContext: any) => Promise<Context>;
+export interface ServerConfiguration<Context = any> {
+  schema?: GraphQLSchema;
+  typeDefs?: any;
+  resolvers?: IResolvers;
+  context?: ContextFn<Context>;
+}
+
 export class GraphQLApp {
   private readonly _modules: GraphQLModule[];
   private _schema: GraphQLSchema;
@@ -165,7 +173,7 @@ export class GraphQLApp {
     return this._resolvers;
   }
 
-  get typeDefs(): any {
+  get typeDefs(): string {
     return this._typeDefs;
   }
 
@@ -235,10 +243,6 @@ export class GraphQLApp {
     return this._injector;
   }
 
-  context = async (context: Context) => {
-    return this.buildContext(context.req);
-  }
-
   async buildContext(networkRequest?: any): Promise<Context> {
     const depGraph = this.getModulesDependencyGraph(this._modules);
     const builtResult = {
@@ -292,5 +296,13 @@ export class GraphQLApp {
     }
 
     return result;
+  }
+  generateServerConfig<T extends ServerConfiguration = any>(extraConfig?: T): T {
+    return Object.assign({
+      schema: this.schema,
+      typeDefs: this.typeDefs,
+      resolvers: this.resolvers,
+      context: reqContext => this.buildContext(reqContext.req),
+    }, extraConfig);
   }
 }


### PR DESCRIPTION
For example with Apollo;
```ts
const serverConfig = graphqlApp.generateServerConfig<ApolloServer.Config>({
introspection: true
});
const server= new ApolloServer(serverConfig);
```