### PR TITLE
[graphql-app] better signature for generateServerConfig

### DIFF
--- a/packages/core/src/graphql-app.ts
+++ b/packages/core/src/graphql-app.ts
@@ -394,11 +394,11 @@ export class GraphQLApp {
     ServerConfiguration extends Partial<BaseServerConfiguration> & IExtraConfig,
     IExtraConfig = Pick<ServerConfiguration, Exclude<keyof ServerConfiguration, keyof BaseServerConfiguration>>
   >(extraConfig?: IExtraConfig): ServerConfiguration {
-    return Object.assign({} as ServerConfiguration, {
+    return Object.assign({} as ServerConfiguration, extraConfig, {
       schema: this.schema,
       typeDefs: this.typeDefs,
       resolvers: this.resolvers,
       context: reqContext => this.buildContext(reqContext.req),
-    }, extraConfig);
+    });
   }
 }


### PR DESCRIPTION
This PR;
- Changes `ContextBuilder` signature; now it has return value `Promise<AppContext>` instead of generic `Context = any`.

- Makes the properties of `BaseServerConfiguration` required, because they're always generated by `graphql-modules` while they're optional in `ServerConfiguration` which extends `Partial<BaseServerConfiguration>`.

- `GraphQLApp.generateServerConfig` method may have typings if the user specifically defines a generic type of GraphQL Server Enviroment's Configuration interface, and the values inside generated server configuration object can be overwritten by `extraConfig` ( which doesn't look safe and good practice for typing validations etc... )

That's why, this PR enhances the signature of `GraphQLApp.generateServerConfig` for some cases;

1st case;
If the user doesn't define a generic for server configuration;
```ts
  const serverConfig = graphqlApp.generateServerConfig({ introspection: true, cache: true });
```
`serverConfig` would have an interface;
```ts
  BaseServerConfiguration & { introspection: boolean, cache: boolean }
```

2nd case;
If the user defines a generic for server configuration and tries to overwrite generated base server configuration properties such as `resolvers`, `typeDefs` etc...
```ts
  const serverConfig = graphqlApp.generateServerConfig<ApolloServer.Config>({ 
    introspection: true, 
    cache: true, 
    schema: SOMETHING // Not allowed
});
```
The way the user attempts to call `generateServerConfig` will throw the TS compilation error like ```'extraConfig' doesn't have the property 'schema'``` , because `extraConfig` parameter excludes `BaseServerConfiguration` properties from `ApolloServer.Config` to make it safer in use.

3rd case;
If the user doesn't define a generic for server configuration and tries to overwrite generated base server configuration properties like the second one, the similar TS error will be thrown.

```ts
  const serverConfig = graphqlApp.generateServerConfig({ 
    introspection: true, 
    cache: true, 
    schema: SOMETHING // Not allowed
});
```

4th case;
The user may not use TS or pass TS validations somehow, the generated server configuration will be protected because of the order of parameters in `Object.assign`.