### PR TITLE
WIP: Introduce Resolvers Handlers

### DIFF
--- a/docs/introduction/implement-your-providers.md
+++ b/docs/introduction/implement-your-providers.md
@@ -80,3 +80,44 @@ export const MyModule = new GraphQLModule({
     ],
 });
 ```
+
+### With Resolvers Handlers
+
+If you implement handler `class`es for your resolvers in GraphQLModule. You can inject **Providers** like you do in other **Providers**.
+
+`modules/my-module/query.handler.ts`
+
+```typescript
+
+import { ResolversHandler } from '@graphql-modules/core';
+import { UserProvider } from './user.provider';
+ @ResolversHandler('Query')
+export class QueryResolvers {
+  constructor(private userProvider: UserProvider){}
+  user(root, { id }){
+    return this.userProvider.getUserById(id);
+  }
+}
+
+```
+
+Then use those resolvers handler in your module definition 
+
+`modules/my-module/index.ts`
+
+ ```typescript
+import { GraphQLModule } from '@graphql-modules/core';
+import * as typeDefs from './schema.graphql';
+import { QueryResolvers } from './query.handler';
+import { UserProvider } from './user.provider';
+ export const myModule = new GraphQLModule({
+    name: 'my-module',
+    typeDefs,
+    resolversHandlers: [
+      QueryResolvers
+    ],
+    providers: [
+      UserProvider
+    ],
+});
+```

--- a/docs/introduction/implement-your-resolvers.md
+++ b/docs/introduction/implement-your-resolvers.md
@@ -62,6 +62,55 @@ export const MyModule = new GraphQLModule({
 
 > We can import from `schema.graphql` because we are doing some bundling tricks, if you need help with it, refer to [Development Environment](/TODO) Section.
 
+## Resolvers Handlers
+
+ You can also use handler `class`es to implement your resolvers. It makes it easier to implement and test, and as your app grows, it's easier to separate your modules to small pieces.
+ `modules/my-module/resolvers-handlers/query.ts`
+
+ ```typescript
+
+import { ResolversHandler } from '@graphql-modules/core';
+ @ResolversHandler('Query')
+export class QueryResolversHandler {
+  user(root, { id }){
+    return {
+      _id: id,
+      username: 'jhon',
+    };
+  }
+}
+```
+
+```typescript
+import { ResolversHandler } from '@graphql-modules/core';
+ @ResolversHandler('User')
+export class UserResolversHandler {
+  id(user){
+    return user._id;
+  }
+  username(user){
+    return user.username;
+  }
+}
+```
+
+`modules/my-module/index.ts`
+
+```typescript
+import { GraphQLModule } from '@graphql-modules/core';
+import * as typeDefs from './schema.graphql';
+import { QueryResolvers } from './resolvers-handlers/query';
+import { UserResolvers } from './resolvers-handlers/user';
+ export const myModule = new GraphQLModule({
+    name: 'my-module',
+    typeDefs,
+    resolversHandlers: [
+      QueryResolversHandler,
+      UserResolversHandler
+    ],
+});
+```
+
 ## With Providers
 
 `Provider`s are first-class citizen in GraphQL Modules - they can interact easily with other modules, access the module's configuration, manage it's lifecycle easily and more.

--- a/docs/introduction/integrate-with-graphql-code-generator.md
+++ b/docs/introduction/integrate-with-graphql-code-generator.md
@@ -38,3 +38,19 @@ Then, add a script in `package.json` to generate types easily.
 }
 ```
 
+Finally, you can use those typings anywhere in your project.
+
+ ```typescript
+import { ResolversHandler, ModuleContext } from '@graphql-modules/core';
+import { QueryResolvers } from './generated-types';
+
+@ResolversHandler('Query')
+export class QueryResolversHandler implements QueryResolvers.Resolvers<ModuleContext> {
+  user(root, args, context){ // root and args are typed here
+    return {
+      _id: args.id,
+      username: 'jhon',
+    };
+  }
+}
+```

--- a/docs/introduction/resolvers-composition.md
+++ b/docs/introduction/resolvers-composition.md
@@ -8,8 +8,6 @@ GraphQL Modules has another powerful feature called Resolvers Composition.
 
 With this feature, you can easily make sure each one of your modules only does what it needs (it's business logic) and does not need to do things that are not related to it.
 
-## With Basic Resolvers
-
 For example - if you have a simple server with authentication, and you wish to make sure that one of your queries is protected and only allowed for authenticated user and for users that has `EDITOR` role set, it means that your resolver need to verify these rules as well:
 
 ```typescript

--- a/examples/basic-with-dependency-injection/package.json
+++ b/examples/basic-with-dependency-injection/package.json
@@ -9,9 +9,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "@graphql-modules/core": "0.2.0",
-    "@graphql-modules/epoxy": "0.2.0",
-    "@graphql-modules/sonar": "0.2.0",
+    "@graphql-modules/core": "*",
+    "@graphql-modules/epoxy": "*",
+    "@graphql-modules/sonar": "*",
     "apollo-server": "2.1.0",
     "graphql": "14.0.2",
     "reflect-metadata": "0.1.12",

--- a/examples/basic-with-dependency-injection/src/modules/blog/index.ts
+++ b/examples/basic-with-dependency-injection/src/modules/blog/index.ts
@@ -1,13 +1,19 @@
 import {GraphQLModule} from '@graphql-modules/core';
 import {Blog} from './providers/blog';
 import gql from 'graphql-tag';
-import resolvers from './resolvers';
 import { UserModule } from '../user';
+import { PostResolversHandler } from './resolvers/post';
+import { QueryResolversHandler } from './resolvers/query';
+import { UserResolversHandler } from './resolvers/user';
 
 export const BlogModule = new GraphQLModule({
   imports: [UserModule],
   providers: [Blog],
-  resolvers,
+  resolversHandlers: [
+    PostResolversHandler,
+    QueryResolversHandler,
+    UserResolversHandler,
+  ],
   typeDefs: gql`
     type Query {
       posts: [Post]

--- a/examples/basic-with-dependency-injection/src/modules/blog/resolvers/index.ts
+++ b/examples/basic-with-dependency-injection/src/modules/blog/resolvers/index.ts
@@ -1,9 +1,0 @@
-import query from './query';
-import user from './user';
-import post from './post';
-
-export default {
-  ...user,
-  ...query,
-  ...post,
-};

--- a/examples/basic-with-dependency-injection/src/modules/blog/resolvers/post.ts
+++ b/examples/basic-with-dependency-injection/src/modules/blog/resolvers/post.ts
@@ -1,11 +1,16 @@
-import { ModuleContext } from '@graphql-modules/core';
-
+import { ResolversHandler } from '@graphql-modules/core';
 import { Blog } from '../providers/blog';
 
-export default {
-  Post: {
-    id: post => post._id,
-    title: post => post.title,
-    author: (post, args, {injector}: ModuleContext) => injector.get(Blog).getAuthor(post.authorId),
-  },
-};
+@ResolversHandler('Post')
+export class PostResolversHandler {
+  constructor(private blog: Blog) {}
+  id(post) {
+    return post._id;
+  }
+  title(post) {
+    return post.title;
+  }
+  author(post) {
+    return this.blog.getAuthor(post.authorId);
+  }
+}

--- a/examples/basic-with-dependency-injection/src/modules/blog/resolvers/query.ts
+++ b/examples/basic-with-dependency-injection/src/modules/blog/resolvers/query.ts
@@ -1,8 +1,10 @@
-import { ModuleContext } from '@graphql-modules/core';
+import { ResolversHandler } from '@graphql-modules/core';
 import { Blog } from '../providers/blog';
 
-export default {
-  Query: {
-    posts: (root, args, { injector }: ModuleContext) => injector.get(Blog).allPosts(),
-  },
-};
+@ResolversHandler('Query')
+export class QueryResolversHandler {
+  constructor(private blog: Blog) {}
+  posts() {
+    return this.blog.allPosts();
+  }
+}

--- a/examples/basic-with-dependency-injection/src/modules/blog/resolvers/user.ts
+++ b/examples/basic-with-dependency-injection/src/modules/blog/resolvers/user.ts
@@ -1,10 +1,10 @@
+import { ResolversHandler } from '@graphql-modules/core';
 import { Blog } from '../providers/blog';
-import { ModuleContext } from '@graphql-modules/core';
 
-// Example with injector in context
-
-export default {
-  User: {
-    posts: (user, args, { injector }: ModuleContext) => injector.get(Blog).getPostsOf(user._id),
-  },
-};
+@ResolversHandler('User')
+export class UserResolversHandler {
+  constructor(private blog: Blog) {}
+  posts(user) {
+    return this.blog.getPostsOf(user._id);
+  }
+}

--- a/examples/basic-with-dependency-injection/src/modules/user/index.ts
+++ b/examples/basic-with-dependency-injection/src/modules/user/index.ts
@@ -1,11 +1,15 @@
 import { GraphQLModule } from '@graphql-modules/core';
 import { Users } from './providers/users';
-import resolvers from './resolvers';
 import gql from 'graphql-tag';
+import { QueryResolversHandler } from './resolvers/query';
+import { UserResolversHandler } from './resolvers/user';
 
 export const UserModule = new GraphQLModule({
   providers: [Users],
-  resolvers,
+  resolversHandlers: [
+    QueryResolversHandler,
+    UserResolversHandler,
+  ],
   typeDefs: gql`
     type User {
       id: String

--- a/examples/basic-with-dependency-injection/src/modules/user/resolvers/index.ts
+++ b/examples/basic-with-dependency-injection/src/modules/user/resolvers/index.ts
@@ -1,7 +1,0 @@
-import query from './query';
-import user from './user';
-
-export default {
-  ...query,
-  ...user,
-};

--- a/examples/basic-with-dependency-injection/src/modules/user/resolvers/query.ts
+++ b/examples/basic-with-dependency-injection/src/modules/user/resolvers/query.ts
@@ -1,9 +1,13 @@
 import { Users } from '../providers/users';
-import { ModuleContext } from '@graphql-modules/core';
+import { ResolversHandler } from '@graphql-modules/core';
 
-export default {
-  Query: {
-    users: (root, args, {injector}: ModuleContext) => injector.get(Users).allUsers(),
-    user: (root, { id }, {injector}: ModuleContext) => injector.get(Users).getUser(id),
-  },
-};
+@ResolversHandler('Query')
+export class QueryResolversHandler {
+  constructor(private _users: Users) {}
+  users() {
+    return this._users.allUsers();
+  }
+  user(_, { id }) {
+    return this._users.getUser(id);
+  }
+}

--- a/examples/basic-with-dependency-injection/src/modules/user/resolvers/user.ts
+++ b/examples/basic-with-dependency-injection/src/modules/user/resolvers/user.ts
@@ -1,6 +1,11 @@
-export default {
-  User: {
-    id: user => user._id,
-    username: user => user.username,
-  },
-};
+import { ResolversHandler } from '@graphql-modules/core';
+
+@ResolversHandler('User')
+export class UserResolversHandler {
+  id(user) {
+    return user._id;
+  }
+  username(user) {
+    return user.username;
+  }
+}

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -2,4 +2,5 @@ export { __decorate as decorate } from 'tslib';
 export { Inject } from './inject';
 export { Injectable } from './injectable';
 export { Injector } from './injector';
+export { ResolversHandler } from './resolvers-handler';
 export * from './types';

--- a/packages/core/src/di/resolvers-handler.ts
+++ b/packages/core/src/di/resolvers-handler.ts
@@ -1,0 +1,11 @@
+import { RESOLVERS_TYPE } from '../utils';
+import { Injectable } from './injectable';
+
+declare var Reflect: any;
+
+export function ResolversHandler(resolversType: string) {
+  return (target: any): any => {
+    Reflect.defineMetadata(RESOLVERS_TYPE, resolversType, target);
+    return Injectable()(target);
+  };
+}

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,6 +1,7 @@
 import { ServiceIdentifier, Provider, Type, ValueProvider, ClassProvider, FactoryProvider, TypeProvider } from './di/types';
 
 export const DESIGN_PARAM_TYPES = 'design:paramtypes';
+export const RESOLVERS_TYPE = 'resolvers-type';
 
 export function getServiceIdentifierName<T>(serviceIdentifier: ServiceIdentifier<T>) {
   if (typeof serviceIdentifier === 'function' && isType<T>(serviceIdentifier)) {


### PR DESCRIPTION
This is a solution to handle strict DI like we discussed before. 
Thanks to classes, we can handle compositions as method/property decorators. 
Other methods ( injecting dependencies using factory function, `injectFn` decorator-like function ) make the code less readable.

```typescript
import { ResolversHandler } from '@graphql-modules/core';
import { withRole } from './compositions';
import { QueryResolvers } from '@models';

@ResolversHandler('Query')
export class QueryResolversHandler implements QueryResolvers.Resolvers {
  constructor(private usersProvider: UsersProvider) {}
  @withRole(ADMIN)
  users(root, args, context, info) { // all parameters and return value are typed
     return this.usersProvider.getUsers(args);
  }
}
```

instead of defining compositions somewhere else, and getting provider on each request which is really error prone in my opinion.

If we use classes as resolvers definitions, user would get DI errors before running that resolver; because dependencies are injected before being assigned as resolvers.

In that way, we can write resolvers better with generated typings instead of this;
```typescript
export const resolvers: QueryResolvers.Resolvers {
   Query: {
       users: (root, args, context, info) => context.injector.get(UsersProvider).getUsers(args)
    }
};
export default resolvers;
```