### PR TITLE
Speed improvements

### DIFF
--- a/docs/guides/development-environment.md
+++ b/docs/guides/development-environment.md
@@ -25,7 +25,7 @@ Next, create (or update, if you already have one) `tsconfig.json` in your root d
   "compilerOptions": {
     "experimentalDecorators": true,
     "module": "commonjs",
-    "target": "es5",
+    "target": "es6",
     "lib": ["es6", "esnext", "es2015"],
     "noImplicitAny": false,
     "suppressImplicitAnyIndexErrors": true,

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -6,7 +6,7 @@ import { ServiceIdentifierNotFoundError, DependencyProviderNotFoundError, Provid
 declare var Reflect: any;
 
 export class Injector {
-  public children = new Array<Injector>();
+  public children = new Set<Injector>();
   private _types = new Set<any>();
   private _valueMap = new Map();
   private _classMap = new Map();

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,7 +17,8 @@
     "alwaysStrict": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "downlevelIteration": true
   },
   "files": ["src/index.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
- Use Set to prevent duplications before merging schema
- Use deepmerge instead of `reduce` for merging array of objects