### PR TITLE
Fix directive merging for GraphQLSchema objects

### DIFF
--- a/packages/epoxy/src/schema-mergers/merge-schema.ts
+++ b/packages/epoxy/src/schema-mergers/merge-schema.ts
@@ -1,4 +1,4 @@
-import { DefinitionNode, DocumentNode, GraphQLSchema, parse, print, printSchema, Source } from 'graphql';
+import { DefinitionNode, DocumentNode, GraphQLSchema, parse, print, Source } from 'graphql';
 import { isGraphQLSchema, isSourceTypes, isStringTypes } from './utils';
 import { MergedResultMap, mergeGraphQLNodes } from './merge-nodes';
 

--- a/packages/epoxy/src/schema-mergers/merge-schema.ts
+++ b/packages/epoxy/src/schema-mergers/merge-schema.ts
@@ -18,7 +18,10 @@ export function mergeGraphQLTypes(types: Array<string | Source | DocumentNode | 
   const allNodes: ReadonlyArray<DefinitionNode> = types
     .map<DocumentNode>(type => {
       if (isGraphQLSchema(type)) {
-        const printedSchema = printSchema(type, { commentDescriptions: true });
+        const typesMap = type.getTypeMap();
+        const allTypesPrinted = Object.keys(typesMap).map(key => typesMap[key]).map(type => type.astNode ? print(type.astNode) : null).filter(e => e);
+        const directivesDeclaration = type.getDirectives().map(directive => directive.astNode ? print(directive.astNode) : null).filter(e => e);
+        const printedSchema = [...directivesDeclaration, ...allTypesPrinted].join('\n');
 
         return parse(printedSchema);
       } else if (isStringTypes(type) || isSourceTypes(type)) {

--- a/packages/epoxy/tests/merge-schema.spec.ts
+++ b/packages/epoxy/tests/merge-schema.spec.ts
@@ -1,5 +1,6 @@
 import { mergeGraphQLSchemas, mergeGraphQLTypes } from '../src/schema-mergers/merge-schema';
 import { makeExecutableSchema } from 'graphql-tools';
+import { printSchema } from 'graphql';
 import { stripWhitespaces } from './utils';
 import gql from 'graphql-tag';
 
@@ -224,6 +225,25 @@ describe('Merge Schema', () => {
           }
         `),
       );
+    });
+
+    it('should merge two GraphQLSchema with directives correctly', () => {
+      const merged = mergeGraphQLSchemas([
+        makeExecutableSchema({
+          typeDefs: [
+            `type Query { f1: MyType }`,
+            `type MyType { f2: String }`,
+          ],
+        }),
+        makeExecutableSchema({
+          typeDefs: [
+            `directive @id on FIELD_DEFINITION`,
+            `type MyType2 { f2: String @id }`,
+          ],
+        }),
+      ]);
+
+      expect(merged).toContain('f2: String @id');
     });
 
     it('should merge the same directives and its locations', () => {


### PR DESCRIPTION
Instead of using `printSchema`, we are using now `print` per each type in the schema, and the same for the directives. `print` preserves directives, while `printSchema` uses introspection and removes it.
