### PR TITLE
WIP: Data sources integration

### DIFF
--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -125,7 +125,7 @@ export class Injector {
         }
       } else if (this._factoryMap.has(serviceIdentifier)) {
         const factory = this._factoryMap.get(serviceIdentifier);
-        const instance = factory(this);
+        const instance = this.call(factory, this);
         if (this.scopeSet.has(serviceIdentifier)) {
           this._instanceMap.set(serviceIdentifier, instance);
         }

--- a/packages/core/src/graphql-module.ts
+++ b/packages/core/src/graphql-module.ts
@@ -390,15 +390,15 @@ export class GraphQLModule<Config = any, Request = any, Context = any> {
         if (typeof resolver === 'function') {
           if (prop !== '__resolveType') {
             typeResolvers[prop] = async (root: any, args: any, appContext: any, info: any) => {
-              const { networkRequest } = appContext;
+              const { networkRequest, dataSources } = appContext;
               const moduleContext = await this.context(networkRequest);
-              return resolver.call(typeResolvers, root, args, moduleContext, info);
+              return resolver.call(typeResolvers, root, args, {...moduleContext as any, dataSources}, info);
             };
           } else {
             typeResolvers[prop] = async (root: any, appContext: any, info: any) => {
-              const { networkRequest } = appContext;
+              const { networkRequest, dataSources } = appContext;
               const moduleContext = await this.context(networkRequest);
-              return resolver.call(typeResolvers, root, moduleContext as any, info);
+              return resolver.call(typeResolvers, root, {...moduleContext as any, dataSources}, info);
             };
           }
         }
@@ -414,9 +414,9 @@ export class GraphQLModule<Config = any, Request = any, Context = any> {
       const compositionArr = asArray(resolversComposition[path]);
       resolversComposition[path] = [
         (next: any) => async (root: any, args: any, appContext: any, info: any) => {
-          const { networkRequest } = appContext;
+          const { networkRequest, dataSources } = appContext;
           const moduleContext = await this.context(networkRequest);
-          return next(root, args, moduleContext, info);
+          return next(root, args, {...moduleContext as any, dataSources}, info);
         },
         ...compositionArr,
       ];


### PR DESCRIPTION
Data Sources can be defined and used in each module, and these data sources use their own module's context, not all application's. And they can be used part of dependency injection as session scope.
```ts
const { RESTDataSource } = require('apollo-datasource-rest');
@Injectable({ 
   scope: ProviderScope.Session 
})
class MoviesAPI extends RESTDataSource {
  // DI can be used here
  constructor(private someOtherProvider: SomeOtherProvider) {
    super();
    this.baseURL = 'https://movies-api.example.com/';
  }

  async getMovie(id) {
    return this.get(`movies/${id}`);
  }

  async getMostViewedMovies(limit = 10) {
    const data = await this.get('movies', {
      per_page: limit,
      order_by: 'most_viewed',
    });
    return data.results;
  }
}
```
```ts
const module = new GraphQLModule({
 providers: [
  MoviesAPI
 ],
 dataSources: ({ injector }) => ({
    movies: injector.get(MoviesAPI)
 })
})
```
or
```ts
const module = new GraphQLModule({
 providers: [
  MoviesAPI
 ],
 dataSources: Inject(MoviesAPI, ActorsAPI)((movies, actors) => ({
    movies,
    actors
 })
})
```

Datasources can be injected using SessionInjector or dataSources property of module context;
```ts
  {
    Query: {
       mostViewedMovies: (root, args, { dataSources }) => dataSources.movies.getMostViewedMovies() 
    }
  }
```
```ts
@Injectable({ 
   scope: ProviderScope.Session 
})
class AnotherSessionScopedProvider {
   constructor(private movies: MoviesAPI){}
}
```