### PR TITLE
Add missing dependency @graphql-modules/di to the examples

### DIFF
--- a/examples/basic-with-dependency-injection/package.json
+++ b/examples/basic-with-dependency-injection/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@graphql-modules/core": "0.2.12",
+    "@graphql-modules/di": "0.2.18",
     "@graphql-modules/epoxy": "0.2.12",
     "@graphql-modules/sonar": "0.2.12",
     "apollo-server": "2.1.0",


### PR DESCRIPTION
`basic-with-dependency-injection` example is lack of `@graphql-modules/di` dependency which is required by both of `User` and `Blog` providers.