### PR TITLE
Implement to use Inject in a property with a breaking change

### DIFF
--- a/packages/di/src/inject.ts
+++ b/packages/di/src/inject.ts
@@ -1,15 +1,27 @@
-import { DESIGN_PARAM_TYPES } from './utils';
+import { DESIGN_PARAM_TYPES, DESIGN_TYPE, PROPERTY_KEYS } from './utils';
 import { ServiceIdentifier, Instances } from './types';
 
-export function Inject<Dependencies extends Array<ServiceIdentifier<any>>, Fn extends (...args: Instances<Dependencies>) => any>(...dependencies: Dependencies) {
-  return (target: Fn, _targetKey?: string, index?: number): any => {
-    let allDependencies = Reflect.getMetadata(DESIGN_PARAM_TYPES, target) || [];
-    if (typeof index !== 'undefined') {
-      allDependencies[index] = dependencies[0];
+export function Inject(dependency?: ServiceIdentifier<any>) {
+  return (target: any, propertyKey?: string, index?: number) => {
+    const allDependencies = Reflect.getMetadata(DESIGN_PARAM_TYPES, target) || [];
+    const propertyKeys = Reflect.getMetadata(PROPERTY_KEYS, target) || [];
+    if (typeof propertyKey === 'undefined') {
+      if (typeof index !== 'undefined') {
+        allDependencies[index] = dependency;
+      }
     } else {
-      allDependencies = dependencies;
+      const designType = dependency || Reflect.getMetadata(DESIGN_TYPE, target, propertyKey);
+      Reflect.defineMetadata(DESIGN_TYPE, designType, target, propertyKey);
+      propertyKeys.push(propertyKey);
     }
     Reflect.defineMetadata(DESIGN_PARAM_TYPES, allDependencies, target);
+    Reflect.defineMetadata(PROPERTY_KEYS, propertyKeys, target);
+    return target;
+  };
+}
+export function InjectFunction<Dependencies extends Array<ServiceIdentifier<any>>, Fn extends (...args: Instances<Dependencies>) => any>(...dependencies: Dependencies) {
+  return (target: Fn): (...args: any[]) => ReturnType<Fn> => {
+    Reflect.defineMetadata(DESIGN_PARAM_TYPES, dependencies, target);
     return target;
   };
 }

--- a/packages/di/src/injectable.ts
+++ b/packages/di/src/injectable.ts
@@ -1,14 +1,13 @@
-import { DESIGN_PARAM_TYPES, PROVIDER_OPTIONS } from './utils';
+import { DESIGN_PARAM_TYPES, PROVIDER_OPTIONS, PROPERTY_KEYS } from './utils';
 import { ProviderOptions } from './types';
 
-export function Injectable(options?: ProviderOptions): ClassDecorator {
-  return (target: any) => {
-    if (!Reflect.hasMetadata(DESIGN_PARAM_TYPES, target)) {
-      Reflect.defineMetadata(DESIGN_PARAM_TYPES, [], target);
-    }
-    if (options) {
-      Reflect.defineMetadata(PROVIDER_OPTIONS, options, target);
-    }
+export function Injectable(options: ProviderOptions = {}): ClassDecorator {
+  return target => {
+    const existingDesignParamTypes = Reflect.getMetadata(DESIGN_PARAM_TYPES, target) || [];
+    Reflect.defineMetadata(DESIGN_PARAM_TYPES, existingDesignParamTypes, target);
+    Reflect.defineMetadata(PROVIDER_OPTIONS, options, target);
+    const propertyKeys = Reflect.getMetadata(PROPERTY_KEYS, target) || [];
+    Reflect.defineMetadata(PROPERTY_KEYS, propertyKeys, target);
     return target;
   };
 }

--- a/packages/di/src/injector.ts
+++ b/packages/di/src/injector.ts
@@ -1,7 +1,7 @@
 
 import { ProviderNotValidError, ServiceIdentifierNotFoundError, DependencyProviderNotFoundError, ProviderAlreadyDefinedError } from './errors';
 import { ServiceIdentifier, Type, Provider, ProviderScope, ProviderOptions, Factory } from './types';
-import { isTypeProvider, PROVIDER_OPTIONS, isValueProvider, isClassProvider, isFactoryProvider, DESIGN_PARAM_TYPES } from './utils';
+import { isTypeProvider, PROVIDER_OPTIONS, isValueProvider, isClassProvider, isFactoryProvider, DESIGN_PARAM_TYPES, DESIGN_TYPE, PROPERTY_KEYS } from './utils';
 
 export class Injector {
   private _classMap = new Map<ServiceIdentifier<any>, Type<any>>();
@@ -109,9 +109,18 @@ export class Injector {
       } else if (this._classMap.has(serviceIdentifier)) {
         const RealClazz = this._classMap.get(serviceIdentifier);
         try {
-          const dependencies = Reflect.getMetadata(DESIGN_PARAM_TYPES, RealClazz) || [];
-          const dependencyInstances = dependencies.map((dependency: ServiceIdentifier<any>) => this.get(dependency));
+          const dependencies: Array<ServiceIdentifier<any>> = Reflect.getMetadata(DESIGN_PARAM_TYPES, RealClazz) || [];
+          const dependencyInstances = dependencies.map(dependency => this.get(dependency));
           const instance = new RealClazz(...dependencyInstances);
+          const propertyKeys = Reflect.getMetadata(PROPERTY_KEYS, RealClazz.prototype) || [];
+          for (const propertyKey of propertyKeys) {
+            const dependency = Reflect.getMetadata(DESIGN_TYPE, RealClazz.prototype, propertyKey);
+            if (dependency) {
+              Object.defineProperty(instance, propertyKey, {
+                value: this.get(dependency),
+              });
+            }
+          }
           if (this.scopeSet.has(serviceIdentifier)) {
             this._instanceMap.set(serviceIdentifier, instance);
           }

--- a/packages/di/src/utils.ts
+++ b/packages/di/src/utils.ts
@@ -1,7 +1,9 @@
 import { ServiceIdentifier, Provider, Type, ValueProvider, ClassProvider, FactoryProvider, TypeProvider } from './types';
 
 export const DESIGN_PARAM_TYPES = 'design:paramtypes';
+export const DESIGN_TYPE = 'design:type';
 export const PROVIDER_OPTIONS = 'provider-options';
+export const PROPERTY_KEYS = 'property-keys';
 
 export function getServiceIdentifierName<T>(serviceIdentifier: ServiceIdentifier<T>) {
   if (typeof serviceIdentifier === 'function' && isType<T>(serviceIdentifier)) {


### PR DESCRIPTION
Now you can use `Inject` in a property without defining constructor.
```
@Injectable()
class FooProvider {
   @Inject()
    barProvider: BarProvider
}
```
BUT due to some typings conflicts, I seperated `Inject` decorator and wrappers, so factory functions should be wrapped with `InjectFunction` not `Inject`.
```
//Before
resolvers: Inject(FooProvider)(fooProvider =>
//After
resolvers: InjectFunction(FooProvider)(fooProvider =>
```