### PR TITLE
chore: add homepage and repository entries for all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "repository": "https://github.com/Urigo/graphql-modules.git",
+  "homepage": "https://graphql-modules.com/",
   "author": "dotansimha <dotansimha@gmail.com>",
   "license": "MIT",
   "workspaces": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@graphql-modules/core",
   "version": "0.3.0",
+  "repository": "https://github.com/Urigo/graphql-modules.git",
   "homepage": "https://graphql-modules.com/",
   "main": "dist/index.js",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@graphql-modules/core",
   "version": "0.3.0",
+  "homepage": "https://graphql-modules.com/",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@graphql-modules/di",
   "version": "0.3.0",
+  "repository": "https://github.com/Urigo/graphql-modules.git",
   "homepage": "https://graphql-modules.com/",
   "main": "dist/index.js",
   "license": "MIT",

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@graphql-modules/di",
   "version": "0.3.0",
+  "homepage": "https://graphql-modules.com/",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/epoxy/package.json
+++ b/packages/epoxy/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@graphql-modules/epoxy",
   "version": "0.3.0",
+  "homepage": "https://graphql-modules.com/",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/epoxy/package.json
+++ b/packages/epoxy/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@graphql-modules/epoxy",
   "version": "0.3.0",
+  "repository": "https://github.com/Urigo/graphql-modules.git",
   "homepage": "https://graphql-modules.com/",
   "main": "dist/index.js",
   "license": "MIT",

--- a/packages/sonar/package.json
+++ b/packages/sonar/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@graphql-modules/sonar",
   "version": "0.3.0",
+  "repository": "https://github.com/Urigo/graphql-modules.git",
   "homepage": "https://graphql-modules.com/",
   "main": "dist/index.js",
   "license": "MIT",

--- a/packages/sonar/package.json
+++ b/packages/sonar/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@graphql-modules/sonar",
   "version": "0.3.0",
+  "homepage": "https://graphql-modules.com/",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@graphql-modules/utils",
   "version": "0.3.0",
+  "homepage": "https://graphql-modules.com/",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@graphql-modules/utils",
   "version": "0.3.0",
+  "repository": "https://github.com/Urigo/graphql-modules.git",
   "homepage": "https://graphql-modules.com/",
   "main": "dist/index.js",
   "license": "MIT",


### PR DESCRIPTION
I have the following function defined in my local shell:

```
npoh () {
	open $(npm view $1 homepage)
}
```

I use that often for viewing documentation. When I ran `npoh @graphql-modules/core` the `open` command failed because there was no homepage entry in `package.json`.

Beyond my particular use case there is no link to the homepage or the repository from npm which made tracking down this repository more difficult than it should have been.