### PR TITLE
Introduce class resolvers

### DIFF
--- a/docs/introduction/implement-your-resolvers.md
+++ b/docs/introduction/implement-your-resolvers.md
@@ -67,3 +67,4 @@ export const MyModule = new GraphQLModule({
 `Provider`s are first-class citizen in GraphQL Modules - they can interact easily with other modules, access the module's configuration, manage it's lifecycle easily and more.
 
 To get to know how to use `Provider`s, in the next step, we will take the previous example and change it to use `Provider`.
+

--- a/packages/class-resolvers/.gitignore
+++ b/packages/class-resolvers/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.idea
+dist
+build
+out
+temp

--- a/packages/class-resolvers/.npmignore
+++ b/packages/class-resolvers/.npmignore
@@ -1,0 +1,5 @@
+src
+node_modules
+tests
+!dist
+tsconfig.json

--- a/packages/class-resolvers/.npmrc
+++ b/packages/class-resolvers/.npmrc
@@ -1,0 +1,1 @@
+save-exact = true

--- a/packages/class-resolvers/package.json
+++ b/packages/class-resolvers/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@graphql-modules/class-resolvers",
+  "version": "0.3.0",
+  "repository": "https://github.com/Urigo/graphql-modules.git",
+  "homepage": "https://graphql-modules.com/",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "lint": "tslint -c ../../tslint.json 'src/**/*.ts' --format stylish"
+  },
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "diagnostics": false
+      }
+    },
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/test-assets"
+    ],
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
+  },
+  "devDependencies": {
+    "jest": "23.6.0",
+    "tslint": "5.12.1",
+    "typescript": "3.2.4"
+  },
+  "dependencies": {
+    "@graphql-modules/core": "0.3.0",
+    "@graphql-modules/di": "0.3.0",
+    "tslib": "1.9.3"
+  },
+  "typings": "./dist/index.d.ts",
+  "typescript": {
+    "definition": "./dist/index.d.ts"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/class-resolvers/src/index.ts
+++ b/packages/class-resolvers/src/index.ts
@@ -1,0 +1,22 @@
+import { Type } from '@graphql-modules/di';
+import { IResolverObject } from 'graphql-tools';
+import { ModuleContext } from '@graphql-modules/core';
+
+export function useClassProviderForTypeResolver<TClassProvider extends Type<any>, TSource, TContext extends ModuleContext>(clazz: TClassProvider): TClassProvider & IResolverObject<TSource, TContext> {
+  if (typeof clazz !== 'function' && !('prototype' in clazz)) {
+    throw new Error(`
+        GraphQL-Modules Error: Provider# NAME_HERE cannot be used as type resolver.
+        - If you want to use a provider as a type resolver, it must be a class provider.
+
+        Possible solutions:
+        - Use class provider instead of factory or value providers.
+      `);
+  }
+  const typeResolver: IResolverObject<TSource, TContext> = {};
+  // tslint:disable-next-line:forin
+  for (const prop in clazz.prototype) {
+    typeResolver[prop] = (root, args, context, info) => context.injector.get(clazz)[prop](root, args, context, info);
+  }
+  return typeResolver as InstanceType<TClassProvider>;
+
+}

--- a/packages/class-resolvers/tests/index.spec.ts
+++ b/packages/class-resolvers/tests/index.spec.ts
@@ -1,0 +1,41 @@
+import 'reflect-metadata';
+import { GraphQLModule } from '@graphql-modules/core';
+import { Injectable, ProviderScope } from '@graphql-modules/di';
+import { useClassProviderForTypeResolver } from '../src';
+import { execute } from 'graphql';
+import gql from 'graphql-tag';
+
+describe('Class Resolvers', async () => {
+  it('should handle resolver classes', async () => {
+    @Injectable({
+      scope: ProviderScope.Session,
+    })
+    class QueryResolvers {
+      foo() {
+        return 'FOO';
+      }
+    }
+
+    const { schema, context } = new GraphQLModule({
+      typeDefs: gql`
+        type Query {
+          foo: String
+        }
+      `,
+      resolvers: {
+        Query: useClassProviderForTypeResolver(QueryResolvers),
+      },
+      providers: [
+        QueryResolvers,
+      ],
+    });
+
+    const result = await execute({
+      schema,
+      document: gql`query { foo }`,
+      contextValue: await context({}),
+    });
+    expect(result.errors).toBeFalsy();
+    expect(result.data['foo']).toBe('FOO');
+  });
+});

--- a/packages/class-resolvers/tsconfig.json
+++ b/packages/class-resolvers/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "target": "es5",
+    "lib": ["es6", "esnext", "es2015"],
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "sourceMap": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "importHelpers": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "files": ["src/index.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Use classes to implement resolvers by installing `@graphql-modules/class-resolvers`

`query.resolvers.ts`
```typescript
import { Injectable, ProviderScope } from '@graphql-modules/di';

@Injectable({
  scope: ProviderScope.Session
})
export class QueryResolvers {
  constructor(private usersProvider: UsersProvider, private moduleSessionInfo: ModuleSessionInfo) {}
  async currentUser(root, args, context, info) {
    const { authToken } = this.moduleSessionInfo.session;
    const user = await this.usersProvider.getUserByToken(authToken);
    return user;
  }
}
```

`my.module.ts`
```typescript
  import { GraphQLModule } from '@graphql-modules/core';
  import { useClassProviderForTypeResolver } from '@graphql-modules/class-resolvers';
  import { QueryResolvers } from './query.resolvers';
  import { UserModule } from './user.module';

  export const MyModule = new GraphQLModule({
    imports: [
      UsersModule // For User type and UserProviders
    ],
    typeDefs: gql`
      type Query {
        currentUser: User
      }
    `,
    resolvers: {
      Query: useClassProviderForTypeResolver(QueryResolvers), // Extract field resolvers
    },
    providers: [
      QueryResolvers, // Define it as class provider for Dependency Injection
    ]
  });
```