### PR TITLE
Support es2015 tree shaking

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,11 +3,10 @@
   "version": "0.4.2",
   "repository": "https://github.com/Urigo/graphql-modules.git",
   "homepage": "https://graphql-modules.com/",
-  "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.es2015.json",
     "lint": "tslint -c ../../tslint.json 'src/**/*.ts' --format stylish"
   },
   "jest": {
@@ -44,6 +43,8 @@
     "tslint": "5.12.1",
     "typescript": "3.3.3"
   },
+  "main": "dist/index.js",
+  "module": "dist/es2015/index.js",
   "typings": "./dist/index.d.ts",
   "typescript": {
     "definition": "./dist/index.d.ts"

--- a/packages/core/tsconfig.es2015.json
+++ b/packages/core/tsconfig.es2015.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "module": "es2015",
+    "target": "es2018",
+    "lib": [
+      "es2018",
+      "esnext.asynciterable"
+    ],
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "sourceMap": true,
+    "inlineSources": true,
+    "declaration": true,
+    "outDir": "./dist/es2015",
+    "rootDir": "./src",
+    "importHelpers": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "downlevelIteration": true
+  },
+  "files": ["src/index.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -3,11 +3,10 @@
   "version": "0.4.2",
   "repository": "https://github.com/Urigo/graphql-modules.git",
   "homepage": "https://graphql-modules.com/",
-  "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.es2015.json",
     "lint": "tslint -c ../../tslint.json 'src/**/*.ts' --format stylish"
   },
   "jest": {
@@ -45,6 +44,8 @@
   "dependencies": {
     "tslib": "1.9.3"
   },
+  "main": "dist/index.js",
+  "module": "dist/es2015/index.js",
   "typings": "./dist/index.d.ts",
   "typescript": {
     "definition": "./dist/index.d.ts"

--- a/packages/di/tsconfig.es2015.json
+++ b/packages/di/tsconfig.es2015.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "module": "es2015",
+    "target": "es2018",
+    "lib": [
+      "es2018",
+      "esnext.asynciterable"
+    ],
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "sourceMap": true,
+    "inlineSources": true,
+    "declaration": true,
+    "outDir": "./dist/es2015",
+    "rootDir": "./src",
+    "importHelpers": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "downlevelIteration": true,
+    "strictFunctionTypes": true
+  },
+  "files": ["src/index.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/graphql-modules/package.json
+++ b/packages/graphql-modules/package.json
@@ -3,11 +3,10 @@
   "version": "0.4.2",
   "repository": "https://github.com/Urigo/graphql-modules.git",
   "homepage": "https://graphql-modules.com/",
-  "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.es2015.json",
     "lint": "tslint -c ../../tslint.json 'src/**/*.ts' --format stylish"
   },
   "jest": {
@@ -42,6 +41,8 @@
     "@graphql-modules/core": "0.4.2",
     "tslib": "1.9.3"
   },
+  "main": "dist/index.js",
+  "module": "dist/es2015/index.js",
   "typings": "./dist/index.d.ts",
   "typescript": {
     "definition": "./dist/index.d.ts"

--- a/packages/graphql-modules/tsconfig.es2015.json
+++ b/packages/graphql-modules/tsconfig.es2015.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "target": "es2018",
+    "lib": [
+      "es2018",
+      "esnext.asynciterable"
+    ],
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "sourceMap": true,
+    "inlineSources": true,
+    "declaration": true,
+    "outDir": "./dist/es2015",
+    "rootDir": "./src",
+    "importHelpers": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "downlevelIteration": true
+  },
+  "files": ["src/index.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
* Add `es2015` bundle
* Change target to `es2018` because NodeJS already supports `es2018`, no need to transpile code.
* Use `tslib` to reduce the code