### PR TITLE
Enhancements for DataSources

### DIFF
--- a/docs/guides/data-sources.md
+++ b/docs/guides/data-sources.md
@@ -6,7 +6,7 @@ sidebar_label: Data sources
 
 As defined in Apollo Server documentation, data sources are specific classes that encapsulates fetching data from a particular service, with built-in support for caching, deduplication and error handling. A data source instance uses the cache of your GraphQL Server, and is passed through your Application Context in normal case.
 
-GraphQL-Modules has built-in support for Data sources in its own encapsulation-based modular dependency injection system. GraphQL-Modules considers Data sources as session-scoped providers, and passes the cache logic of the module.
+GraphQL-Modules has built-in support for Data sources in its own encapsulation-based modular dependency injection system. GraphQL-Modules considers Data sources as providers, and passes the cache logic of the module.
 
 Let's assume you have a data source class for the communication between your external REST API. The only you do is to add `Injectable` decorator for this class to make it able to be part of GraphQL-Modules DI.
 
@@ -19,9 +19,7 @@ To learn more about Data Sources, check Apollo docs;
   import { RESTDataSource } from 'apollo-datasource-rest';
   import { Injectable } from '@graphql-modules/di';
 
-  @Injectable({
-    scope: ProviderScope.Session
-  })
+  @Injectable()
   export class MoviesAPI extends RESTDataSource {
     baseURL = 'https://movies-api.example.com/';
 
@@ -115,11 +113,11 @@ As described in Apollo Server docs, GraphQL-Modules also uses in-memory caching 
 You can share GraphQL-Modules cache mechanism with your GraphQL Server;
 
 ```typescript
-  const { schema, cache } = YourGraphQLModule;
+  const { schema, selfCache } = YourGraphQLModule;
 
   new ApolloServer({
     schema,
-    cache
+    cache: selfCache
   });
 ```
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@graphql-modules/di": "0.6.6",
+    "apollo-server-caching": "0.3.1",
     "graphql-toolkit": "0.2.9",
     "graphql-tools": "4.0.4",
     "tslib": "1.9.3"

--- a/packages/core/src/module-session-info.ts
+++ b/packages/core/src/module-session-info.ts
@@ -18,7 +18,7 @@ export class ModuleSessionInfo<Config = any, Session extends object = any, Conte
     return this._session;
   }
   get cache() {
-    return this.module.cache;
+    return this.module.selfCache;
   }
   context: ModuleContext<Context>;
   get injector() {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,7 +26,7 @@ export interface OnDisconnect<WebSocket = any, ConnectionContext = any, OnDiscon
   onDisconnect?: (websocket: WebSocket, connectionSession: ConnectionContext) => OnDisconnectResult;
 }
 
-export interface ISubscriptionHooks<
+export interface SubscriptionHooks<
   ConnectionParams = object,
   WebSocket = any,
   ConnectionSession = any,

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -44,6 +44,7 @@
     "typescript": "3.4.1"
   },
   "dependencies": {
+    "events": "3.0.0",
     "tslib": "1.9.3"
   },
   "sideEffects": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -599,6 +599,13 @@ apollo-link@^1.2.3:
     apollo-utilities "^1.0.0"
     zen-observable-ts "^0.8.10"
 
+apollo-server-caching@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.3.1.tgz#63fcb2aaa176e1e101b36a8450e6b4c593d2767a"
+  integrity sha512-mfxzikYXbB/OoEms77AGYwRh7FF3Oim5v5XWAL+VL49FrkbZt5lopVa4bABi7Mz8Nt3Htl9EBJN8765s/yh8IA==
+  dependencies:
+    lru-cache "^5.0.0"
+
 apollo-utilities@1.1.2, apollo-utilities@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.1.2.tgz#aa5eca9d1f1eb721c381a22e0dde03559d856db3"
@@ -1749,6 +1756,11 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
+
+events@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
+  integrity sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==
 
 exec-sh@^0.3.2:
   version "0.3.2"
@@ -3771,6 +3783,13 @@ lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+lru-cache@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
 
 make-dir@^1.0.0, make-dir@^1.3.0:
   version "1.3.0"
@@ -5938,6 +5957,11 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yallist@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
 yargs-parser@10.x:
   version "10.1.0"


### PR DESCRIPTION
* Able to use DataSources without Session Scope
* `initialize` is no more a hook, so `initialize` is only called immediately after the instantitation of the provider
* Use Apollo's LRU Cache mechanism to prevent high memory usage for default GQL Modules mechanism
