### PR TITLE
Fixes for memory usage

### DIFF
--- a/packages/core/src/graphql-module.ts
+++ b/packages/core/src/graphql-module.ts
@@ -1076,10 +1076,11 @@ export class GraphQLModule<Config = any, Session extends object = any, Context =
                 if ('res' in session && 'once' in session['res']) {
                   if (!('_onceFinishListeners' in session['res'])) {
                     session['res']['_onceFinishListeners'] = [];
-                    session['res'].once('finish', async (e: any) => {
+                    session['res'].once('finish', (e: any) => {
                       if ('_onceFinishListeners' in session['res']) {
-                        await Promise.all(session['res']['_onceFinishListeners'].map((onceFinishListener: any) => onceFinishListener(e)));
-                        delete session['res']['_onceFinishListeners'];
+                        Promise.all(session['res']['_onceFinishListeners'].map((onceFinishListener: any) => onceFinishListener(e))).then(() => {
+                          delete session['res']['_onceFinishListeners'];
+                        });
                       }
                     });
                   }

--- a/packages/core/src/graphql-module.ts
+++ b/packages/core/src/graphql-module.ts
@@ -1074,26 +1074,21 @@ export class GraphQLModule<Config = any, Session extends object = any, Context =
                 }
                 moduleSessionInfo.context = Object.assign<any, Context>(importsContext, moduleContext);
                 if ('res' in session && 'once' in session['res']) {
-                  if (!('_onceFinishListeners' in session['res'])) {
-                    session['res']['_onceFinishListeners'] = [];
-                    session['res'].once('finish', (e: any) => {
-                      if ('_onceFinishListeners' in session['res']) {
-                        Promise.all(session['res']['_onceFinishListeners'].map((onceFinishListener: any) => onceFinishListener(e))).then(() => {
+                    if (!('_onceFinishListeners' in session['res'])) {
+                      session['res']['_onceFinishListeners'] = [];
+                      session['res'].once('finish', (e: any) => {
+                          const onceFinishListeners = session['res']['_onceFinishListeners'];
+                          onceFinishListeners.map((onceFinishListener: any) => onceFinishListener(e));
                           delete session['res']['_onceFinishListeners'];
-                        });
-                      }
+                      });
+                    }
+                    session['res']['_onceFinishListeners'].push(() => {
+                        sessionInjector.callHookWithArgsAsync({
+                            hook: 'onResponse',
+                            args: [moduleSessionInfo],
+                            instantiate: true,
+                        }).then(() => this.destroySelfSession(session));
                     });
-                  }
-                  session['res']['_onceFinishListeners'].push(() => {
-                    const onResponse$ = sessionInjector.callHookWithArgs({
-                      hook: 'onResponse',
-                      args: [moduleSessionInfo],
-                      instantiate: true,
-                      async: true,
-                    });
-                    this.destroySelfSession(session);
-                    return onResponse$;
-                  });
                 }
                 sessionInjector.onInstanceCreated = ({ instance }) => {
                   if (

--- a/packages/di/src/injector.ts
+++ b/packages/di/src/injector.ts
@@ -260,7 +260,7 @@ export class Injector<Session extends object = any> {
       sessionInjector._factoryMap = this._factoryMap;
       sessionInjector._applicationScopeServiceIdentifiers = this._applicationScopeServiceIdentifiers;
       sessionInjector._requestScopeServiceIdentifiers = this._requestScopeServiceIdentifiers;
-      sessionInjector._sessionScopeServiceIdentifiers = this._sessionScopeServiceIdentifiers;
+      sessionInjector._sessionScopeServiceIdentifiers = [...this._sessionScopeServiceIdentifiers];
       this._sessionSessionInjectorMap.set(session, sessionInjector);
     }
     return this._sessionSessionInjectorMap.get(session);


### PR DESCRIPTION
* Do not use promise as the return value of promise 
* Clone sessionProviders into Session Injector to prevent duplication of ModuleSessionInfo