### PR TITLE
chore: add subscription implemention demonstration with apollo-server 2.0

### DIFF
--- a/examples/subscription-with-apolloer-server/README.md
+++ b/examples/subscription-with-apolloer-server/README.md
@@ -4,17 +4,11 @@ The server side implementation of Graphql subscription with apollo-server and Gr
 
 ## HOW TO START
 
-- clone the repository
-
-```bash
-  git clone git@github.com:dancon/apollo-server_graphql-modules_subscriptions.git
-```
+- download the zip and cd into examples/subscription-with-apollo-server
 
 - install the dependencies
 
 ```bash
-  cd apollo-server_graphql-modules_subscriptions
-
   npm i
 ```
 

--- a/examples/subscription-with-apolloer-server/README.md
+++ b/examples/subscription-with-apolloer-server/README.md
@@ -1,0 +1,80 @@
+# apollo-server_graphql-modules_subscriptions
+
+The server side implementation of Graphql subscription with apollo-server and Graphql Modules.
+
+## HOW TO START
+
+- clone the repository
+
+```bash
+  git clone git@github.com:dancon/apollo-server_graphql-modules_subscriptions.git
+```
+
+- install the dependencies
+
+```bash
+  cd apollo-server_graphql-modules_subscriptions
+
+  npm i
+```
+
+- start the project in debug mode in VSCode or just excute the command below
+
+```bash
+  npm start
+```
+
+## Demonstration
+
+open `http://localhost:4000/graphql` in your browser, you will see the graphql playground, and excute oprations below in different tabs.
+
+- Subscription
+
+```graphql
+  subscription {
+    indicatorUpdated (psm: "ts") {
+      host
+      risk
+    }
+  }
+```
+
+- Mutation
+
+```graphql
+  mutation {
+    updateIndicators (psm: "t1", payload: [ { host: "t1", risk: false } ]) {
+      host
+      risk
+    }
+  }
+````
+
+## NEED TO KNOW
+
+- Make sure the version of `@graphql-modules/core` and `@graphql-modules/di` is `0.7.1` or upper.
+
+- If you are using `apollo-server-koa`, please use `http.createServer(app.callback())` to wrap http server.
+
+- When use `Subscription transformation`, you must keep the reture type of `resolve` function in correspondence with the definition in the schema.
+
+resolvers.ts
+
+```typescript
+  Subscription: {
+    indicatorUpdated: {
+      resolve(payload) {
+        console.log('subscription transformation:', payload)
+
+        // the reture type MUST be in correspondence with the definition in the schema.
+        return [
+          {
+            host: '改了',
+            risk: false
+          }
+        ]
+      },
+      subscribe: (_, __, { injector }: ModuleContext) => injector.get(PubSub).asyncIterator(['indicatorUpdated'])
+    }
+  }
+```

--- a/examples/subscription-with-apolloer-server/README.md
+++ b/examples/subscription-with-apolloer-server/README.md
@@ -46,7 +46,7 @@ open `http://localhost:4000/graphql` in your browser, you will see the graphql p
 
 ## NEED TO KNOW
 
-- Make sure the version of `@graphql-modules/core` and `@graphql-modules/di` is `0.7.1` or upper.
+- Make sure the versions of `@graphql-modules/core` and `@graphql-modules/di` are `0.7.1` or higher.
 
 - If you are using `apollo-server-koa`, please use `http.createServer(app.callback())` to wrap http server.
 

--- a/examples/subscription-with-apolloer-server/package.json
+++ b/examples/subscription-with-apolloer-server/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "dev": "nodemon index.js",
+    "copy:graphql": "cpy schemas/**/*.graphql ../lib --cwd=src --parents",
+    "build": "cross-env NODE_ENV=production tsc -p . && npm run copy:graphql",
+    "debug": "cross-env NODE_ENV=development node --nolazy --inspect-brk=9229 ./node_modules/.bin/ts-node src/index.ts",
+    "start": "npm run build && node lib/index.js"
+  },
+  "dependencies": {
+    "@graphql-modules/core": "^0.7.1",
+    "@graphql-modules/di": "^0.7.1",
+    "apollo-server-express": "^2.4.8",
+    "express": "^4.16.4",
+    "graphql": "^14.1.1",
+    "graphql-import-node": "0.0.3",
+    "graphql-subscriptions": "^1.1.0",
+    "graphql-tools": "^4.0.4",
+    "reflect-metadata": "^0.1.13",
+    "subscriptions-transport-ws": "^0.9.16"
+  },
+  "devDependencies": {
+    "@playlyfe/gql": "^2.6.1",
+    "@types/graphql": "^14.2.0",
+    "@types/node": "^11.13.4",
+    "cpy-cli": "^2.0.0",
+    "cross-env": "^5.2.0",
+    "nodemon": "^1.18.11",
+    "ts-node": "^8.1.0",
+    "typescript": "^3.4.3"
+  }
+}

--- a/examples/subscription-with-apolloer-server/src/index.ts
+++ b/examples/subscription-with-apolloer-server/src/index.ts
@@ -1,0 +1,35 @@
+// import { ApolloServer } from 'apollo-server-koa'
+import { GraphQLModule } from '@graphql-modules/core'
+
+import express from 'express'
+import { ApolloServer } from 'apollo-server-express'
+import { createServer } from 'http'
+
+import * as graphqlModules from './schemas'
+
+const gmodules: GraphQLModule[] = []
+Object.keys(graphqlModules).forEach((key) => {
+  gmodules.push(graphqlModules[key])
+})
+
+const { schema, context, subscriptions } = new GraphQLModule({
+  imports: gmodules
+})
+
+const server = new ApolloServer({
+  schema,
+  context,
+  subscriptions
+})
+
+// const app: any = new Koa()
+const app = express()
+server.applyMiddleware({ app })
+
+const httpServer = createServer(app)
+server.installSubscriptionHandlers(httpServer)
+
+httpServer.listen({ port: 4000 }, () => {
+  console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`)
+  console.log(`🚀 Subsciription ready at ws://localhost:4000${server.subscriptionsPath}`)
+})

--- a/examples/subscription-with-apolloer-server/src/schemas/index.ts
+++ b/examples/subscription-with-apolloer-server/src/schemas/index.ts
@@ -1,0 +1,2 @@
+import 'reflect-metadata'
+export { default as Subscription } from './subscription'

--- a/examples/subscription-with-apolloer-server/src/schemas/subscription/index.ts
+++ b/examples/subscription-with-apolloer-server/src/schemas/subscription/index.ts
@@ -1,0 +1,12 @@
+import 'graphql-import-node'
+import { GraphQLModule } from '@graphql-modules/core'
+import { PubSub } from 'apollo-server-express'
+
+import * as typeDefs from './schema.graphql'
+import resolvers from './resolvers'
+
+export default new GraphQLModule({
+  typeDefs,
+  resolvers,
+  providers: [PubSub]
+})

--- a/examples/subscription-with-apolloer-server/src/schemas/subscription/resolvers.ts
+++ b/examples/subscription-with-apolloer-server/src/schemas/subscription/resolvers.ts
@@ -1,0 +1,49 @@
+import { ModuleContext } from '@graphql-modules/core'
+import { PubSub } from 'apollo-server-express'
+
+const indicators = [
+  {
+    host: 't1',
+    risk: false
+  },
+  {
+    host: 't2',
+    risk: true
+  }
+]
+
+export default {
+  Query: {
+    indicators() {
+      return indicators
+    }
+  },
+  Mutation: {
+    updateIndicators(_, { psm, payload }, { injector }: ModuleContext) {
+      const pubsub = injector.get(PubSub)
+      console.log('update:', psm, payload)
+      pubsub.publish('indicatorUpdated', {
+        indicatorUpdated: payload,
+        psm
+      })
+      return payload
+    }
+  },
+
+  Subscription: {
+    indicatorUpdated: {
+      resolve(payload) {
+        console.log('subscription transformation:', payload)
+
+        // the reture type MUST be in correspondence with the definition in the schema.
+        return [
+          {
+            host: '改了',
+            risk: false
+          }
+        ]
+      },
+      subscribe: (_, __, { injector }: ModuleContext) => injector.get(PubSub).asyncIterator(['indicatorUpdated'])
+    }
+  }
+}

--- a/examples/subscription-with-apolloer-server/src/schemas/subscription/schema.graphql
+++ b/examples/subscription-with-apolloer-server/src/schemas/subscription/schema.graphql
@@ -1,0 +1,21 @@
+type Query {
+  indicators (psm: String!): [Indicator!]!
+}
+
+type Mutation {
+  updateIndicators (psm: String!, payload: [IndicatorPayload!]!): [Indicator!]!
+}
+
+type Subscription {
+  indicatorUpdated (psm: String!): [Indicator!]!
+}
+
+type Indicator {
+  host: String
+  risk: Boolean
+}
+
+input IndicatorPayload {
+  host: String
+  risk: Boolean
+}

--- a/examples/subscription-with-apolloer-server/tsconfig.json
+++ b/examples/subscription-with-apolloer-server/tsconfig.json
@@ -1,0 +1,79 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "lib": [
+      "es6",
+      "dom",
+      "esnext",
+      "es2016"
+    ], /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true, /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true, /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "lib", /* Redirect output structure to the directory. */
+    "rootDir": "src", /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "incremental": true,                   /* Enable incremental compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    /* Strict Type-Checking Options */
+    "strict": true, /* Enable all strict type-checking options. */
+    "noImplicitAny": false, /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    /* Module Resolution Options */
+    "moduleResolution": "node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "baseUrl": "./", /* Base directory to resolve non-absolute module names. */
+    "paths": {
+      "common/*": [
+        "src/common/*"
+      ]
+    }, /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    "allowSyntheticDefaultImports": true, /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    /* Experimental Options */
+    "experimentalDecorators": true, /* Enables experimental support for ES7 decorators. */
+    "emitDecoratorMetadata": true, /* Enables experimental support for emitting type metadata for decorators. */
+    /* Advanced Options */
+    "resolveJsonModule": true, /* Include modules imported with '.json' extension */
+    "suppressImplicitAnyIndexErrors": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/dynamic/index.js"
+  ],
+  "files": [
+    "src/index.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
It's tough when implement subscription with apollo-server without a demonstration for a fresh of graphql.

@ardatan please check it when you are free, hope can help more person. 