### PR TITLE
selfCache getter overwriting with default when already defined issue

### DIFF
--- a/packages/core/src/graphql-module.ts
+++ b/packages/core/src/graphql-module.ts
@@ -1186,6 +1186,8 @@ export class GraphQLModule<
       } else {
         this._cache.selfKeyValueCache = null;
       }
+    } else {
+      cache = this._cache.selfKeyValueCache;
     }
     return cache;
   }


### PR DESCRIPTION
the cache is always reset to default on subsequent get after getting it the first time

(expect the same issue on selfLogger)