### PR TITLE
Include connectionParams to the subscription context call

### DIFF
--- a/packages/core/src/graphql-module.ts
+++ b/packages/core/src/graphql-module.ts
@@ -730,12 +730,11 @@ export class GraphQLModule<
                   );
                   const importsOnConnectHooks = await Promise.all(importsOnConnectHooks$);
                   const importsResult = importsOnConnectHooks.reduce((acc, curr) => ({ ...acc, ...(curr || {}) }), {});
-
-                  const connectionModuleContext = await this.context({...connectionContext, connectionParams});
+                  const connectionModuleContext = await this.context({ ...connectionContext, connectionParams });
                   const sessionInjector = connectionModuleContext.injector;
                   const hookResult = await sessionInjector.callHookWithArgs({
                     hook: 'onConnect',
-                    args: [connectionParams, websocket, connectionContext],
+                    args: [connectionParams, websocket, connectionModuleContext],
                     instantiate: true,
                     async: true
                   });
@@ -839,7 +838,7 @@ export class GraphQLModule<
                   const sessionInjector = connectionModuleContext.injector;
                   await sessionInjector.callHookWithArgs({
                     hook: 'onDisconnect',
-                    args: [websocket, connectionContext],
+                    args: [websocket, connectionModuleContext],
                     instantiate: true,
                     async: true
                   });

--- a/packages/core/src/graphql-module.ts
+++ b/packages/core/src/graphql-module.ts
@@ -730,7 +730,8 @@ export class GraphQLModule<
                   );
                   const importsOnConnectHooks = await Promise.all(importsOnConnectHooks$);
                   const importsResult = importsOnConnectHooks.reduce((acc, curr) => ({ ...acc, ...(curr || {}) }), {});
-                  const connectionModuleContext = await this.context(connectionContext);
+
+                  const connectionModuleContext = await this.context({...connectionContext, connectionParams});
                   const sessionInjector = connectionModuleContext.injector;
                   const hookResult = await sessionInjector.callHookWithArgs({
                     hook: 'onConnect',


### PR DESCRIPTION
closes #694 

in order to access the `connectionParams` from within the module **context function** of a **subscription** operation, we need to explicitly pass it down, otherwise, there is no way of decorating the context for subscriptions