### PR TITLE
Replace debug script according to ts-node docs

### DIFF
--- a/docs/recipes/development-environment.md
+++ b/docs/recipes/development-environment.md
@@ -52,7 +52,7 @@ Next, add the following scripts to your `package.json`:
 {
   "scripts": {
     "dev": "nodemon --exec ts-node src/main.ts",
-    "debug": "nodemon --exec ts-node --inspect --debug-brk src/index.ts",
+    "debug": "nodemon --exec node -r ts-node/register --inspect src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js"
   }


### PR DESCRIPTION
Small fix in environment docs.
Per [https://github.com/TypeStrong/ts-node/issues/537](https://github.com/TypeStrong/ts-node/issues/537) the way of being able to run inspector is `-r ts-node/register`. I hit this issue while trying to debug in vscode

Hope it helps! cheers!