### PR TITLE
Fix issue with hook provider resolution when using custom provide option

### DIFF
--- a/packages/core/tests/graphql-module.spec.ts
+++ b/packages/core/tests/graphql-module.spec.ts
@@ -500,6 +500,42 @@ describe('GraphQLModule', () => {
       expect(counter).toBe(3);
     });
 
+    it('should call onRequest hook on each session when using injection tokens', async () => {
+      const providerToken = 'FooProvider';
+
+      let counter = 0;
+      @Injectable()
+      class FooProvider implements OnRequest {
+        onRequest() {
+          counter++;
+        }
+      }
+
+      const { schema } = new GraphQLModule({
+        typeDefs: gql`
+          type Query {
+            foo: String
+          }
+        `,
+        resolvers: {
+          Query: {
+            foo: () => ''
+          }
+        },
+        providers: [{ provide: providerToken, useClass: FooProvider }]
+      });
+      await execute({
+        schema,
+
+        document: gql`
+          query {
+            foo
+          }
+        `
+      });
+      expect(counter).toBe(1);
+    });
+
     it('should pass network session to onRequest hook', async () => {
       const fooSession = {
         foo: 'bar'

--- a/packages/di/src/injector.ts
+++ b/packages/di/src/injector.ts
@@ -139,7 +139,7 @@ export class Injector<Session extends object = any> {
           if (!this._hookServiceIdentifiersMap.has(hook)) {
             this._hookServiceIdentifiersMap.set(hook, []);
           }
-          this._hookServiceIdentifiersMap.get(hook).push(provider.useClass);
+          this._hookServiceIdentifiersMap.get(hook).push(provider.provide);
         }
       }
     } else if (isFactoryProvider(provider)) {


### PR DESCRIPTION
When using token-injection based session providers with hooks I was running into an error:

```
GraphQL-Modules Error: Dependency Provider Not Found!
      - Provider #_AuthProvider not provided in #Module AUTH_MODULE _SESSION scope!
   
Possible solutions:
      - Check if you have this provider in your module.
      - Check if you have the module of this provider imported in your dependent modules.
```

After digging deeper this appeared to be an issue with how there was a difference in how the provider was identified between `_hookServiceIdentifiersMap` and `_sessionScopeInstanceMap`. The hooks map was using the class that was passed as the `useClass` option whereas the session scope map was using the `provide` option.

This changes the way the hooks map identifies the provider so that it uses the `provide` option which fixes the issue.