### PR TITLE
Adding wild cards example to resolvers composition docs

### DIFF
--- a/docs/introduction/resolvers-composition.md
+++ b/docs/introduction/resolvers-composition.md
@@ -31,8 +31,8 @@ const resolvers = {
       }
 
       return false;
-    }
-  }
+    },
+  },
 };
 ```
 
@@ -54,8 +54,8 @@ const resolvers = {
       }
 
       return false;
-    }
-  }
+    },
+  },
 };
 ```
 
@@ -64,7 +64,7 @@ And let's create utility functions in different files with the logic we have rem
 We can implement it just like a GraphQL resolver; we now need to tell GraphQL Modules that the process has been okay by using the `next` function.
 
 ```typescript
-export const isAuthenticated = () => next => async (root, args, context, info) => {
+export const isAuthenticated = () => (next) => async (root, args, context, info) => {
   if (!context.currentUser) {
     throw new Error('You are not authenticated!');
   }
@@ -72,7 +72,7 @@ export const isAuthenticated = () => next => async (root, args, context, info) =
   return next(root, args, context, info);
 };
 
-export const hasRole = (role: string) => next => async (root, args, context, info) => {
+export const hasRole = (role: string) => (next) => async (root, args, context, info) => {
   if (!context.currentUser.roles || context.currentUser.roles.includes(role)) {
     throw new Error('You are not authorized!');
   }
@@ -89,14 +89,29 @@ import { GraphQLModule } from '@graphql-modules/core';
 const MyModule = new GraphQLModule({
   /*...*/
   resolversComposition: {
-    'Query.myQuery': [isAuthenticated(), hasRole('EDITOR')]
-  }
+    'Query.myQuery': [isAuthenticated(), hasRole('EDITOR')],
+  },
 });
 ```
 
 Before each execution of the `myQuery` resolver, GraphQL Modules makes sure to execute `isAuthenticated` and `hasRole`.
 
-> This feature is useful for things like authentication, authorization, permissions, keeping things like last activity, verifying that objects exists and a lot more!
+Furthermore, if our logic applies to more than one resolver under `Query`, we can use wild cards.
+
+```typescript
+import { GraphQLModule } from '@graphql-modules/core';
+
+const MyModule = new GraphQLModule({
+  /*...*/
+  resolversComposition: {
+    'Query.*': [isAuthenticated(), hasRole('EDITOR')],
+  },
+});
+```
+
+In this case, Before each execution of any resolver under `Query`, GraphQL Modules makes sure to execute `isAuthenticated` and `hasRole`.
+
+> This feature is useful for things like authentication, authorization, permissions, keeping things like last activity, verifying that objects exist and a lot more!
 
 The great thing about resolvers composition is that each of our resolvers just does its own job without unrelated logic and the app can extend resolvers later on arbitrary rules.
 


### PR DESCRIPTION
This PR provides an example of `resolversComposition` using wild cards. 

### Context
given the issue https://github.com/Urigo/graphql-modules/issues/1015 I've decided to extend the example given on `resolversComposition` to surface wild-cards as an option. 

This is nothing new, but the documentation doesn't hint that the feature exists, and we can only know this when digging into [graphlq-toolkit repo](https://github.com/ardatan/graphql-toolkit/blob/master/packages/common/src/resolvers-composition.ts#L41-L72). I think it's a great feature and simplifies a lot the use of `resolversComposition` on GraphQL Modules