### PR TITLE
Allow access to the app/singleton injector

### DIFF
--- a/packages/graphql-modules/src/application/application.ts
+++ b/packages/graphql-modules/src/application/application.ts
@@ -326,6 +326,7 @@ export function createApplication(config: ApplicationConfig): Application {
     typeDefs,
     resolvers,
     schema,
+    injector: appInjector,
     createSubscription,
     createExecution,
     createSchemaForApollo() {

--- a/packages/graphql-modules/src/application/types.ts
+++ b/packages/graphql-modules/src/application/types.ts
@@ -1,5 +1,5 @@
 import { execute, subscribe, DocumentNode, GraphQLSchema } from 'graphql';
-import { Provider } from '../di';
+import { Provider, Injector } from '../di';
 import { Resolvers, Module } from '../module/types';
 import { Single } from '../shared/types';
 import { MiddlewareMap } from '../shared/middleware';
@@ -24,6 +24,10 @@ export type Application = {
    * Ready to use GraphQLSchema object combined from modules.
    */
   readonly schema: GraphQLSchema;
+  /**
+   * The application (Singleton) injector.
+   */
+  readonly injector: Injector;
   /**
    * Creates a `subscribe` function that runs the subscription phase of GraphQL.
    * Important when using GraphQL Subscriptions.

--- a/packages/graphql-modules/tests/index.spec.ts
+++ b/packages/graphql-modules/tests/index.spec.ts
@@ -663,6 +663,11 @@ test('Use useFactory with deps', async () => {
   expect(requestSpy).toHaveBeenCalledWith(request);
 });
 
+test('Application allows injector access', () => {
+  const app = createApplication({ modules: [] });
+  expect(app.injector).toBeDefined();
+});
+
 // test("testModule testing util", async () => {
 //   @Injectable()
 //   class Posts {

--- a/packages/graphql-modules/tests/index.spec.ts
+++ b/packages/graphql-modules/tests/index.spec.ts
@@ -664,8 +664,13 @@ test('Use useFactory with deps', async () => {
 });
 
 test('Application allows injector access', () => {
-  const app = createApplication({ modules: [] });
-  expect(app.injector).toBeDefined();
+  @Injectable()
+  class SomeProvider {}
+  const { injector } = createApplication({
+    modules: [],
+    providers: [SomeProvider],
+  });
+  expect(injector.get(SomeProvider)).toBeInstanceOf(SomeProvider);
 });
 
 // test("testModule testing util", async () => {


### PR DESCRIPTION
A benign example:

```
const { injector } = createApplication(...)

server.listen({ port }, () => {
  const logger = injector.get(Logger)
  logger.info(`server ready at http://localhost:${port} 🚀`)
})
```
I ultimately use it for other things, but you get the idea. Cheers!