### PR TITLE
fix(create application): merge resolvers

### DIFF
--- a/packages/graphql-modules/package.json
+++ b/packages/graphql-modules/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@graphql-tools/schema": "^6.0.0",
     "@graphql-tools/wrap": "^6.0.0",
+    "@graphql-tools/merge": "^6.0.0",
     "ramda": "0.27.1"
   },
   "publishConfig": {

--- a/packages/graphql-modules/src/application/application.ts
+++ b/packages/graphql-modules/src/application/application.ts
@@ -105,11 +105,12 @@ export function createApplication(config: ApplicationConfig): Application {
 
   // Creating a schema, flattening the typedefs and resolvers
   // is not expensive since it happens only once
-  const typeDefs = mergeTypeDefs(flatten(modules.map((mod) => mod.typeDefs)));
-  const resolvers = mergeResolvers(
-    modules.map((mod) => mod.resolvers).filter(isDefined)
-  );
-  const schema = makeExecutableSchema({ typeDefs, resolvers });
+  const typeDefs = flatten(modules.map((mod) => mod.typeDefs));
+  const resolvers = modules.map((mod) => mod.resolvers).filter(isDefined);
+  const schema = makeExecutableSchema({
+    typeDefs: mergeTypeDefs(typeDefs),
+    resolvers: mergeResolvers(resolvers),
+  });
 
   // This is very critical. It creates an execution context.
   // It has to run on every operation.

--- a/packages/graphql-modules/src/application/application.ts
+++ b/packages/graphql-modules/src/application/application.ts
@@ -21,6 +21,7 @@ import { ID, Maybe } from '../shared/types';
 import { ModuleDuplicatedError } from '../shared/errors';
 import tapAsyncIterator, {
   flatten,
+  isDefined,
   isAsyncIterable,
   once,
   uniqueId,
@@ -106,7 +107,7 @@ export function createApplication(config: ApplicationConfig): Application {
   // is not expensive since it happens only once
   const typeDefs = flatten(modules.map((mod) => mod.typeDefs));
   const resolvers = mergeResolvers(
-    modules.map((mod) => mod.resolvers).filter(Boolean)
+    modules.map((mod) => mod.resolvers).filter(isDefined)
   );
   const schema = makeExecutableSchema({ typeDefs, resolvers });
 

--- a/packages/graphql-modules/src/application/application.ts
+++ b/packages/graphql-modules/src/application/application.ts
@@ -9,7 +9,7 @@ import {
   GraphQLTypeResolver,
 } from 'graphql';
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { mergeResolvers } from '@graphql-tools/merge';
+import { mergeResolvers, mergeTypeDefs } from '@graphql-tools/merge';
 import { wrapSchema } from '@graphql-tools/wrap';
 import {
   ReflectiveInjector,
@@ -105,7 +105,7 @@ export function createApplication(config: ApplicationConfig): Application {
 
   // Creating a schema, flattening the typedefs and resolvers
   // is not expensive since it happens only once
-  const typeDefs = flatten(modules.map((mod) => mod.typeDefs));
+  const typeDefs = mergeTypeDefs(flatten(modules.map((mod) => mod.typeDefs)));
   const resolvers = mergeResolvers(
     modules.map((mod) => mod.resolvers).filter(isDefined)
   );

--- a/packages/graphql-modules/src/application/application.ts
+++ b/packages/graphql-modules/src/application/application.ts
@@ -9,6 +9,7 @@ import {
   GraphQLTypeResolver,
 } from 'graphql';
 import { makeExecutableSchema } from '@graphql-tools/schema';
+import { mergeResolvers } from '@graphql-tools/merge';
 import { wrapSchema } from '@graphql-tools/wrap';
 import {
   ReflectiveInjector,
@@ -105,7 +106,7 @@ export function createApplication(config: ApplicationConfig): Application {
   // Creating a schema, flattening the typedefs and resolvers
   // is not expensive since it happens only once
   const typeDefs = flatten(modules.map((mod) => mod.typeDefs));
-  const resolvers = modules.map((mod) => mod.resolvers).filter(isDefined);
+  const resolvers = mergeResolvers(modules.map((mod) => mod.resolvers).filter(Boolean));
   const schema = makeExecutableSchema({ typeDefs, resolvers });
 
   // This is very critical. It creates an execution context.

--- a/packages/graphql-modules/src/application/application.ts
+++ b/packages/graphql-modules/src/application/application.ts
@@ -21,7 +21,6 @@ import { ID, Maybe } from '../shared/types';
 import { ModuleDuplicatedError } from '../shared/errors';
 import tapAsyncIterator, {
   flatten,
-  isDefined,
   isAsyncIterable,
   once,
   uniqueId,
@@ -106,7 +105,9 @@ export function createApplication(config: ApplicationConfig): Application {
   // Creating a schema, flattening the typedefs and resolvers
   // is not expensive since it happens only once
   const typeDefs = flatten(modules.map((mod) => mod.typeDefs));
-  const resolvers = mergeResolvers(modules.map((mod) => mod.resolvers).filter(Boolean));
+  const resolvers = mergeResolvers(
+    modules.map((mod) => mod.resolvers).filter(Boolean)
+  );
   const schema = makeExecutableSchema({ typeDefs, resolvers });
 
   // This is very critical. It creates an execution context.
@@ -339,8 +340,8 @@ export function createApplication(config: ApplicationConfig): Application {
           count: number;
           session: {
             onDestroy(): void;
-            context: InternalAppContext
-          }
+            context: InternalAppContext;
+          };
         }
       > = {};
       const subscription = createSubscription();
@@ -357,7 +358,7 @@ export function createApplication(config: ApplicationConfig): Application {
               onDestroy() {
                 if (--sessions[ctx[CONTEXT_ID]].count === 0) {
                   onDestroy();
-                  delete sessions[ctx[CONTEXT_ID]]
+                  delete sessions[ctx[CONTEXT_ID]];
                 }
               },
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,6 +339,15 @@
     is-promise "4.0.0"
     tslib "~2.0.0"
 
+"@graphql-tools/merge@^6.0.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-6.1.0.tgz#5c9d09b2387514f4b2d679a2e2b15335cee95f15"
+  integrity sha512-dD7J/LELhy87+5V8pko5EhSx2leoRIT02V5coa6S19PTiNrVqCJU/fMMKdWC1FmHSWUYOf+wZhItsilUxPr7XQ==
+  dependencies:
+    "@graphql-tools/schema" "6.1.0"
+    "@graphql-tools/utils" "6.1.0"
+    tslib "~2.0.1"
+
 "@graphql-tools/schema@6.0.18", "@graphql-tools/schema@^6.0.0":
   version "6.0.18"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-6.0.18.tgz#243eb370e4cded00767202bbabf0893f65c3f5b9"
@@ -347,10 +356,26 @@
     "@graphql-tools/utils" "6.0.18"
     tslib "~2.0.0"
 
+"@graphql-tools/schema@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-6.1.0.tgz#8176bf3b56dc1e78243a5f01646c7abbc9921d26"
+  integrity sha512-AZflTf9HU3Uy8UgUwxwFXN9Lf+9D36LBoDRIxPRhsj6EtawbwCqsd3UFwNek0OgiwNi3BL2b+D+6QEcw2IOsDA==
+  dependencies:
+    "@graphql-tools/utils" "6.1.0"
+    tslib "~2.0.1"
+
 "@graphql-tools/utils@6.0.18":
   version "6.0.18"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-6.0.18.tgz#bba960f0ab327c8304089d41da0b7a3e00fe430f"
   integrity sha512-8ntYuXJucBtjViOYljeKBzScfpVTnv7BfqIPU/WJ65h6nXD+qf8fMUR1C4MpCUeFvSjMiDSB5Z4enJmau/9D3A==
+  dependencies:
+    "@ardatan/aggregate-error" "0.0.1"
+    camel-case "4.1.1"
+
+"@graphql-tools/utils@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-6.1.0.tgz#a8ab67bb8d8a879f40d29b334f48de6e6be71c41"
+  integrity sha512-YcyslZ/8rk5nQOGnkEDp/xi6Xphu0mgjh5LTZ1qUio5P+d95/9MW44cPdmi3Feg4kO8u+1GcPC+685hFpJlZJw==
   dependencies:
     "@ardatan/aggregate-error" "0.0.1"
     camel-case "4.1.1"
@@ -8023,7 +8048,7 @@ tslib@^1.10.0, tslib@^1.11.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@~2.0.0:
+tslib@~2.0.0, tslib@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==


### PR DESCRIPTION
every modules passes its own resolvers and typedefs. Which means it also holds its own query/mutation/subscription. We have to merge these resolvers in order to pass 1 schema eventually.

Question: i dont know how to prevent two modules having same naming for a type/resolver while actually being different? And i dont know if this is what you want :)

closes #1300