### PR TITLE
Expose context builder for more fine grained access

### DIFF
--- a/packages/graphql-modules/src/application/application.ts
+++ b/packages/graphql-modules/src/application/application.ts
@@ -152,6 +152,7 @@ export function createApplication(
       createExecution,
       createSchemaForApollo,
       createApolloExecutor,
+      contextBuilder,
       ɵfactory: applicationFactory,
       ɵconfig: config,
     };

--- a/packages/graphql-modules/src/application/context.ts
+++ b/packages/graphql-modules/src/application/context.ts
@@ -16,6 +16,7 @@ export type ExecutionContextBuilder<
 ) => {
   context: InternalAppContext;
   onDestroy: () => void;
+  injector: ReflectiveInjector;
 };
 
 export function createContextBuilder({
@@ -178,6 +179,7 @@ export function createContextBuilder({
     });
 
     return {
+      injector: operationAppInjector,
       onDestroy: once(() => {
         providersToDestroy.forEach(([injector, keyId]) => {
           // If provider was instantiated

--- a/packages/graphql-modules/src/application/types.ts
+++ b/packages/graphql-modules/src/application/types.ts
@@ -10,6 +10,7 @@ import { Resolvers, Module, MockedModule } from '../module/types';
 import { Single, ValueOrPromise } from '../shared/types';
 import { MiddlewareMap } from '../shared/middleware';
 import { ApolloRequestContext } from './apollo';
+import { ExecutionContextBuilder } from './context';
 
 type Execution = typeof execute;
 type Subscription = typeof subscribe;
@@ -53,6 +54,9 @@ export interface Application {
    * Important when using GraphQL Queries and Mutations.
    */
   createExecution(options?: { execute?: typeof execute }): Execution;
+
+  contextBuilder: ExecutionContextBuilder<GraphQLModules.GlobalContext>;
+
   /**
    * Experimental
    */

--- a/packages/graphql-modules/src/testing/test-application.ts
+++ b/packages/graphql-modules/src/testing/test-application.ts
@@ -36,6 +36,9 @@ export function mockApplication(app: Application): MockedApplication {
       createApolloExecutor() {
         return sharedFactory().createApolloExecutor();
       },
+      contextBuilder(context: GraphQLModules.GlobalContext) {
+        return sharedFactory().contextBuilder(context);
+      },
       get ɵfactory() {
         return sharedFactory().ɵfactory;
       },
@@ -52,6 +55,7 @@ export function mockApplication(app: Application): MockedApplication {
           ),
         });
       },
+
       addProviders(newProviders: Provider[]) {
         const config = sharedFactory().ɵconfig;
         const existingProviders =

--- a/packages/graphql-modules/tests/execution-context.spec.ts
+++ b/packages/graphql-modules/tests/execution-context.spec.ts
@@ -498,3 +498,27 @@ test('accessing a singleton provider with execution context in another singleton
     getDependencyName: expectedName,
   });
 });
+
+test('accessing a provider manually', async () => {
+  @Injectable({
+    scope: Scope.Operation,
+    global: true,
+  })
+  class Foo {}
+
+  const mod = createModule({
+    id: 'mod',
+    providers: [Foo],
+    typeDefs: [],
+  });
+
+  const app = createApplication({
+    modules: [mod],
+  });
+
+  const { injector } = app.contextBuilder({
+    hello: 'hello',
+  } as any);
+
+  expect(injector.get(Foo)).toBeInstanceOf(Foo);
+});


### PR DESCRIPTION
Hi, in relation to #1541 I found a way to cleanly expose the context builder and the injector in order to have more fine-grained control on the application module execution context.

In this way, we are able to manually access the contextual injector!


```ts
  @Injectable({
    scope: Scope.Operation,
    global: true,
  })
  class Foo {}

  const mod = createModule({
    id: 'mod',
    providers: [Foo],
    typeDefs: [],
  });

  const app = createApplication({
    modules: [mod],
  });

  const { injector } = app.contextBuilder({
    hello: 'hello',
  });


  injector.get(Foo); // Foo
```