### PR TITLE
Manual control of GraphQL operation

### DIFF
--- a/.changeset/twelve-flies-care.md
+++ b/.changeset/twelve-flies-care.md
@@ -1,0 +1,5 @@
+---
+'graphql-modules': minor
+---
+
+Manual control of GraphQL operation

--- a/packages/graphql-modules/src/application/application.ts
+++ b/packages/graphql-modules/src/application/application.ts
@@ -22,6 +22,7 @@ import { createContextBuilder } from './context';
 import { executionCreator } from './execution';
 import { subscriptionCreator } from './subscription';
 import { apolloSchemaCreator, apolloExecutorCreator } from './apollo';
+import { operationControllerCreator } from './operation-controller';
 import { Module } from '../module/types';
 
 export type ModulesMap = Map<ID, ResolvedModule>;
@@ -126,6 +127,9 @@ export function createApplication(
       operationGlobalProvidersMap,
     });
 
+    const createOperationController = operationControllerCreator({
+      contextBuilder,
+    });
     const createSubscription = subscriptionCreator({ contextBuilder });
     const createExecution = executionCreator({ contextBuilder });
     const createSchemaForApollo = apolloSchemaCreator({
@@ -148,6 +152,7 @@ export function createApplication(
       resolvers,
       schema,
       injector: appInjector,
+      createOperationController,
       createSubscription,
       createExecution,
       createSchemaForApollo,

--- a/packages/graphql-modules/src/application/context.ts
+++ b/packages/graphql-modules/src/application/context.ts
@@ -1,4 +1,4 @@
-import { ReflectiveInjector } from '../di';
+import { Injector, ReflectiveInjector } from '../di';
 import { ResolvedProvider } from '../di/resolution';
 import { ID } from '../shared/types';
 import { once } from '../shared/utils';
@@ -15,7 +15,8 @@ export type ExecutionContextBuilder<
   context: TContext
 ) => {
   context: InternalAppContext;
-  onDestroy: () => void;
+  ɵdestroy(): void;
+  ɵinjector: Injector;
 };
 
 export function createContextBuilder({
@@ -58,7 +59,6 @@ export function createContextBuilder({
       });
     }
 
-    let operationAppInjector: ReflectiveInjector;
     let appContext: GraphQLModules.AppContext;
 
     attachGlobalProvidersMap({
@@ -98,7 +98,7 @@ export function createContextBuilder({
     // As the name of the Injector says, it's an Operation scoped Injector
     // Application level
     // Operation scoped - means it's created and destroyed on every GraphQL Operation
-    operationAppInjector = ReflectiveInjector.createFromResolved({
+    const operationAppInjector = ReflectiveInjector.createFromResolved({
       name: 'App (Operation Scope)',
       providers: appLevelOperationProviders.concat(
         ReflectiveInjector.resolve([
@@ -178,7 +178,7 @@ export function createContextBuilder({
     });
 
     return {
-      onDestroy: once(() => {
+      ɵdestroy: once(() => {
         providersToDestroy.forEach(([injector, keyId]) => {
           // If provider was instantiated
           if (injector._isObjectDefinedByKeyId(keyId)) {
@@ -188,6 +188,7 @@ export function createContextBuilder({
         });
         contextCache = {};
       }),
+      ɵinjector: operationAppInjector,
       context: sharedContext,
     };
   };

--- a/packages/graphql-modules/src/application/execution.ts
+++ b/packages/graphql-modules/src/application/execution.ts
@@ -31,11 +31,13 @@ export function executionCreator({
       typeResolver?: Maybe<GraphQLTypeResolver<any, any>>
     ) => {
       // Create an execution context
-      const { context, onDestroy } = contextBuilder(
-        isNotSchema<ExecutionArgs>(argsOrSchema)
-          ? argsOrSchema.contextValue
-          : contextValue
-      );
+      const { context, ɵdestroy: destroy } =
+        options?.controller ??
+        contextBuilder(
+          isNotSchema<ExecutionArgs>(argsOrSchema)
+            ? argsOrSchema.contextValue
+            : contextValue
+        );
 
       const executionArgs: ExecutionArgs = isNotSchema<ExecutionArgs>(
         argsOrSchema
@@ -59,7 +61,7 @@ export function executionCreator({
       // so we can easily control the end of execution (with finally)
       return Promise.resolve()
         .then(() => executeFn(executionArgs))
-        .finally(onDestroy);
+        .finally(destroy);
     };
   };
 

--- a/packages/graphql-modules/src/application/operation-controller.ts
+++ b/packages/graphql-modules/src/application/operation-controller.ts
@@ -1,0 +1,20 @@
+import type { Application } from './types';
+import type { ExecutionContextBuilder } from './context';
+
+export function operationControllerCreator(options: {
+  contextBuilder: ExecutionContextBuilder<GraphQLModules.GlobalContext>;
+}): Application['createOperationController'] {
+  const { contextBuilder } = options;
+
+  return (input) => {
+    const operation = contextBuilder(input.context);
+    const ɵdestroy = input.autoDestroy ? operation.ɵdestroy : () => {};
+
+    return {
+      context: operation.context,
+      injector: operation.ɵinjector,
+      destroy: operation.ɵdestroy,
+      ɵdestroy,
+    };
+  };
+}

--- a/packages/graphql-modules/src/application/subscription.ts
+++ b/packages/graphql-modules/src/application/subscription.ts
@@ -34,11 +34,13 @@ export function subscriptionCreator({
       subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
     ) => {
       // Create an subscription context
-      const { context, onDestroy } = contextBuilder(
-        isNotSchema<SubscriptionArgs>(argsOrSchema)
-          ? argsOrSchema.contextValue
-          : contextValue
-      );
+      const { context, ɵdestroy: destroy } =
+        options?.controller ??
+        contextBuilder(
+          isNotSchema<SubscriptionArgs>(argsOrSchema)
+            ? argsOrSchema.contextValue
+            : contextValue
+        );
 
       const subscriptionArgs: SubscriptionArgs = isNotSchema<SubscriptionArgs>(
         argsOrSchema
@@ -67,13 +69,13 @@ export function subscriptionCreator({
         .then((sub) => {
           if (isAsyncIterable(sub)) {
             isIterable = true;
-            return tapAsyncIterator(sub, onDestroy);
+            return tapAsyncIterator(sub, destroy);
           }
           return sub;
         })
         .finally(() => {
           if (!isIterable) {
-            onDestroy();
+            destroy();
           }
         });
     };

--- a/packages/graphql-modules/src/application/types.ts
+++ b/packages/graphql-modules/src/application/types.ts
@@ -5,11 +5,12 @@ import {
   GraphQLSchema,
   ExecutionResult,
 } from 'graphql';
-import { Provider, Injector } from '../di';
-import { Resolvers, Module, MockedModule } from '../module/types';
-import { Single, ValueOrPromise } from '../shared/types';
-import { MiddlewareMap } from '../shared/middleware';
-import { ApolloRequestContext } from './apollo';
+import type { Provider, Injector } from '../di';
+import type { Resolvers, Module, MockedModule } from '../module/types';
+import type { MiddlewareMap } from '../shared/middleware';
+import type { ApolloRequestContext } from './apollo';
+import type { Single, ValueOrPromise } from '../shared/types';
+import type { InternalAppContext } from './application';
 
 type Execution = typeof execute;
 type Subscription = typeof subscribe;
@@ -44,15 +45,28 @@ export interface Application {
    */
   readonly injector: Injector;
   /**
+   * Take over control of GraphQL Operation
+   */
+  createOperationController(input: {
+    context: any;
+    autoDestroy?: boolean;
+  }): OperationController;
+  /**
    * Creates a `subscribe` function that runs the subscription phase of GraphQL.
    * Important when using GraphQL Subscriptions.
    */
-  createSubscription(options?: { subscribe?: typeof subscribe }): Subscription;
+  createSubscription(options?: {
+    subscribe?: typeof subscribe;
+    controller?: OperationController;
+  }): Subscription;
   /**
    * Creates a `execute` function that runs the execution phase of GraphQL.
    * Important when using GraphQL Queries and Mutations.
    */
-  createExecution(options?: { execute?: typeof execute }): Execution;
+  createExecution(options?: {
+    execute?: typeof execute;
+    controller?: OperationController;
+  }): Execution;
   /**
    * Experimental
    */
@@ -60,7 +74,9 @@ export interface Application {
   /**
    * Experimental
    */
-  createApolloExecutor(): ApolloExecutor;
+  createApolloExecutor(options?: {
+    controller?: OperationController;
+  }): ApolloExecutor;
   /**
    * @internal
    */
@@ -69,6 +85,22 @@ export interface Application {
    * @internal
    */
   ɵconfig: ApplicationConfig;
+}
+
+export interface OperationController {
+  /**
+   * Destroys
+   */
+  destroy(): void;
+  /**
+   * @internal
+   */
+  ɵdestroy(): void;
+  context: InternalAppContext;
+  /**
+   * Operation Injector (application)
+   */
+  injector: Injector;
 }
 
 /**

--- a/packages/graphql-modules/src/testing/graphql.ts
+++ b/packages/graphql-modules/src/testing/graphql.ts
@@ -1,6 +1,6 @@
 import type { DocumentNode, ExecutionArgs, ExecutionResult } from 'graphql';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
-import type { Application } from '../application/types';
+import type { Application, OperationController } from '../application/types';
 import type { ValueOrPromise } from '../shared/types';
 
 export function execute<
@@ -11,9 +11,12 @@ export function execute<
   inputs: Omit<ExecutionArgs, 'schema'> & {
     document: DocumentNode | TypedDocumentNode<TResult, TVariables>;
     variableValues?: TVariables;
+  },
+  options?: {
+    controller?: OperationController;
   }
 ): ValueOrPromise<ExecutionResult<TResult>> {
-  const executor = app.createExecution();
+  const executor = app.createExecution(options);
 
   return executor({
     schema: app.schema,

--- a/packages/graphql-modules/src/testing/test-application.ts
+++ b/packages/graphql-modules/src/testing/test-application.ts
@@ -24,6 +24,9 @@ export function mockApplication(app: Application): MockedApplication {
       get injector() {
         return sharedFactory().injector;
       },
+      createOperationController(options) {
+        return sharedFactory().createOperationController(options);
+      },
       createSubscription(options) {
         return sharedFactory().createSubscription(options);
       },

--- a/packages/graphql-modules/tests/operation-controller.spec.ts
+++ b/packages/graphql-modules/tests/operation-controller.spec.ts
@@ -1,0 +1,207 @@
+import 'reflect-metadata';
+import {
+  createApplication,
+  createModule,
+  gql,
+  testkit,
+  Injectable,
+  Scope,
+  OnDestroy,
+} from '../src';
+
+test('should share context and injection', async () => {
+  @Injectable({ scope: Scope.Operation })
+  class Data {
+    enabled = true;
+    enable() {
+      this.enabled = true;
+    }
+    disable() {
+      this.enabled = false;
+    }
+  }
+
+  const mod = createModule({
+    id: 'test',
+    typeDefs: [
+      gql`
+        type Query {
+          enabled: Boolean
+        }
+      `,
+    ],
+    resolvers: {
+      Query: {
+        enabled(_: any, __: any, { injector }: GraphQLModules.ModuleContext) {
+          return injector.get(Data).enabled;
+        },
+      },
+    },
+  });
+
+  const app = createApplication({
+    modules: [mod],
+    providers: [Data],
+  });
+
+  const controller = app.createOperationController({
+    context: {},
+  });
+
+  const data = controller.injector.get(Data);
+
+  const query = {
+    document: gql`
+      {
+        enabled
+      }
+    `,
+  };
+
+  expect(
+    await testkit.execute(app, query, {
+      controller,
+    })
+  ).toMatchObject({
+    data: {
+      enabled: true,
+    },
+  });
+
+  data.disable();
+
+  expect(
+    await testkit.execute(app, query, {
+      controller,
+    })
+  ).toMatchObject({
+    data: {
+      enabled: false,
+    },
+  });
+});
+
+test('execution should not destroy operation', async () => {
+  const destroySpy = jest.fn();
+
+  @Injectable({ scope: Scope.Operation })
+  class Data implements OnDestroy {
+    enabled = true;
+    enable() {
+      this.enabled = true;
+    }
+    disable() {
+      this.enabled = false;
+    }
+
+    onDestroy() {
+      destroySpy();
+    }
+  }
+
+  const mod = createModule({
+    id: 'test',
+    typeDefs: [
+      gql`
+        type Query {
+          enabled: Boolean
+        }
+      `,
+    ],
+    resolvers: {
+      Query: {
+        enabled(_: any, __: any, { injector }: GraphQLModules.ModuleContext) {
+          return injector.get(Data).enabled;
+        },
+      },
+    },
+  });
+
+  const app = createApplication({
+    modules: [mod],
+    providers: [Data],
+  });
+
+  const controller = app.createOperationController({
+    context: {},
+  });
+
+  const query = {
+    document: gql`
+      {
+        enabled
+      }
+    `,
+  };
+
+  await testkit.execute(app, query, {
+    controller,
+  });
+
+  expect(destroySpy).not.toHaveBeenCalled();
+
+  controller.destroy();
+
+  expect(destroySpy).toHaveBeenCalledTimes(1);
+});
+
+test('autoDestroy enabled should destroy operation after execution', async () => {
+  const destroySpy = jest.fn();
+
+  @Injectable({ scope: Scope.Operation })
+  class Data implements OnDestroy {
+    enabled = true;
+    enable() {
+      this.enabled = true;
+    }
+    disable() {
+      this.enabled = false;
+    }
+
+    onDestroy() {
+      destroySpy();
+    }
+  }
+
+  const mod = createModule({
+    id: 'test',
+    typeDefs: [
+      gql`
+        type Query {
+          enabled: Boolean
+        }
+      `,
+    ],
+    resolvers: {
+      Query: {
+        enabled(_: any, __: any, { injector }: GraphQLModules.ModuleContext) {
+          return injector.get(Data).enabled;
+        },
+      },
+    },
+  });
+
+  const app = createApplication({
+    modules: [mod],
+    providers: [Data],
+  });
+
+  const controller = app.createOperationController({
+    context: {},
+    autoDestroy: true,
+  });
+
+  const query = {
+    document: gql`
+      {
+        enabled
+      }
+    `,
+  };
+
+  await testkit.execute(app, query, {
+    controller,
+  });
+
+  expect(destroySpy).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
The entire flow of GraphQL operation is being handled by `execute` or `subscribe` function that GraphQL Modules provides. That's the default and controlling those phases makes sure GM cleans everything after each request. In v0 this flow was dependent on `request` and `response` object which was causing many issues (memory leaks, awkward handling of subscriptions).

This PR introduces a new API. The object called `OperationController` is now responsible for managing the flow of GraphQL operation. The `OperationController` enables developer to access Operation-Scoped Injector (of application) before GraphQL Execution or Subscription begins and it's possible to access the Injector even after it happens.

A very important thing to understand is: you own the operation flow, so you're in charge of cleanups and keeping things correct.

To create `OperationController`:

```typescript
const app = createApplication({
  modules: [...],
  providers: [...],
});

const controller = app.createOperationController({
  context: {...},
});
```

To use `OperationController` in `execute`:

```typescript
server.post(async (req, res) => {
  const controller = app.createOperationController({
    context: {...},
  });
  
  const execute = app.createExecution({ controller });
  
  await yourGraphQLHandlingLogic({ schema, execute });
  
  controller.destroy();
});
```

There's also `autoDestroy` flag where developer doesn't have to call `destroy()` after GraphQL Execution.

```typescript
```typescript
server.post(async (req, res) => {
  const controller = app.createOperationController({
    context: {...},
    autoDestroy: true // now GraphQL Modules will destroy the session when GraphQL Execution finishes
  });
  
  const execute = app.createExecution({ controller });
  
  await yourGraphQLHandlingLogic({ schema, execute });
});
```

Reference #1541