### PR TITLE
Added Github action for Declarative label declaration, Standard Labels added for The Guild

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,24 @@
+- color: ea0932
+  description: Something isn't working
+  name: bug
+- color: bfd4f2
+  description: Pull requests that update a dependency file
+  name: dependencies
+- color: 2C3E50
+  description: ""
+  name: docs
+- color: 0e8a16
+  description: Good for newcomers
+  name: good first issue
+- color: ECF0F1
+  description: ""
+  name: legacy
+- color: 1d76db
+  description: ""
+  name: waiting for release
+- color: 006B75
+  description: ""
+  name: work in progress
+- color: fbca04
+  description: ""
+  name: ☂️ umbrella issue

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -1,0 +1,18 @@
+name: Sync labels
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/labels.yml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manifest: .github/labels.yml
+          prune: false


### PR DESCRIPTION
## Description

@Urigo was looking to standardize the labels used in all the repos across The Guild to enable easier management. This PR is for the same.

- All labels are declared declaratively now with the help of this action to sync the same: https://github.com/micnncim/action-label-syncer
- Master Labels for all the repos are managed in this repo: https://github.com/the-guild-org/shared-resources and are pushed to all the repos using PAT whenever changes are made there
- Repo specific labels are added to the repo with an action to help them sync

**NOTE:** This does not remove any of the existing labels or changes the labels in the existing issues to avoid any trouble. It just adds new ones. Relabelling of issues would be required in the future

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

This is how it looks in the codegen repo - its similar here

![image](https://user-images.githubusercontent.com/1165845/114175928-29a84f00-9958-11eb-9b2f-11f6434b6ee8.png)

![image](https://user-images.githubusercontent.com/1165845/114175938-2dd46c80-9958-11eb-9778-a99dd255a67f.png)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project

**CC:** @dotansimha 