### PR TITLE
Adjust the documentation to comply to the implementation

### DIFF
--- a/website/docs/get-started.md
+++ b/website/docs/get-started.md
@@ -38,15 +38,17 @@ values={[
 To create a Module, use `createModule`:
 
 ```typescript
-import { createModule } from 'graphql-modules';
+import { createModule, gql } from 'graphql-modules';
 
 export const myModule = createModule({
   id: 'my-module',
   dirname: __dirname,
   typeDefs: [
-    `type Query {
-      hello: String!
-    }`,
+    gql`
+        type Query {
+            hello: String!
+        }
+    `,
   ],
   resolvers: {
     Query: {


### PR DESCRIPTION
## Description

The `typeDef` requires a `DocumentNode`, not a string:

![image](https://user-images.githubusercontent.com/77624664/114422809-e4358d00-9bb6-11eb-9161-fca222707ff6.png)

Fixes  https://github.com/Urigo/graphql-modules/issues/1636

## Type of change
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

