### PR TITLE
docs: Adding a link to the ts metadata plugin for babel

### DIFF
--- a/website/docs/di/introduction.md
+++ b/website/docs/di/introduction.md
@@ -12,14 +12,14 @@ GraphQL Modules lets you choose whether to use dependency injection or not.
 
 :::caution Usage Requirements
 
-GraphQL Modules depend on **Reflect API** for reflection and for defining dependencies between DI parts, please install and import `reflect-metadata` before every other module.
+GraphQL Modules depend on **Reflect API** and specifically **design:paramtypes** for reflection and for defining dependencies between DI parts, please install and import `reflect-metadata` before every other module.
 
 ```typescript
 import 'reflect-metadata';
 /* code */
-```
 
-:::
+If you are using Babel, please be aware that the preset **@babel/preset-typescript** strips out all the metadata and breaks DI. To overcome this, please use the following plugin: https://www.npmjs.com/package/babel-plugin-transform-typescript-metadata  
+```
 
 ## Introduction
 


### PR DESCRIPTION
Updating docs to better guide babel users to use the DI section of GraphQL Modules