### PR TITLE
Fixes 1732: Fix the failure of missing session when multi-mutation operation

### DIFF
--- a/packages/graphql-modules/src/application/apollo.ts
+++ b/packages/graphql-modules/src/application/apollo.ts
@@ -71,6 +71,7 @@ export function apolloSchemaCreator({
               if (--sessions[ctx[CONTEXT_ID]].count === 0) {
                 destroy();
                 delete sessions[ctx[CONTEXT_ID]];
+                delete ctx[CONTEXT_ID];
               }
             },
           },


### PR DESCRIPTION
## Description

Based on debugging the issue, it appears that while we delete session on end of each mutation, we do not delete the corresponding context key. In the beginning of the next mutation, the session looks for the context key and crashes with `undefined` .

While I'm not 100% sure that it is the right idea to delete the key or even the session on the end of every mutation, this fixes the visible problem. It might be better if they could share the same session (I believe that is what we have the count for). Such a fix, however, would be a bigger design change and beyond my skills with this module.

Fixes #1732  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran the automated tests but I did not create a new one to verify the fix & issue. If this is needed to get the MR accepted, I'll try to get grasp of the tests and create one, but I need a bit of advice on which of the existing tests this relates to most, or if I could create a new suite, but need a bit of advice on what its scope would be.

In my experiments this appears on every operation of type:

```
mutation {
	a: someMutation(...) { ... }
  
	b: otherMutation(...) { ... }
}

```
**Test Environment**:

- OS: OS/X Big Sur 11.4
- `@graphql-modules/...`: master branch
- NodeJS: 14.17.2

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
