### PR TITLE
Fix typo in migration doco

### DIFF
--- a/website/docs/recipes/migration.md
+++ b/website/docs/recipes/migration.md
@@ -132,7 +132,7 @@ To use:
 ```typescript
 const myModule = createModule({
   // ...
-  middlwares: {
+  middlewares: {
     Query: {
       me: [yourMiddleware],
     },


### PR DESCRIPTION
## Description

Fix a typo'd `createModule` property in the migration doco.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules