### PR TITLE
Fix typo in lifecycle doco

### DIFF
--- a/website/docs/advanced/lifecycles.md
+++ b/website/docs/advanced/lifecycles.md
@@ -63,12 +63,12 @@ const app = createApplication({
   providers: [Data],
 });
 
-server.use('/graphq', (req, res) => {
+server.use('/graphql', (req, res) => {
   const controller = app.createOperationController({
     /*
       It's important to pass a correct context value here.
       This value represents a context object available in Dependency Injection.
-      Keep on mind, it doesn't have to be the same context object as your resolvers get.
+      Keep in mind, it doesn't have to be the same context object as your resolvers get.
     */
     context: {},
   });


### PR DESCRIPTION
## Description

Fix a typo'd `graphql` reference in the lifecycle doco.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules