### PR TITLE
[deploy_website] fix(nav): broken documentation link since the update to docusaurus@2 beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 **GraphQL Modules** is a toolset of libraries and guidelines dedicated to **create reusable, maintainable, testable and extendable modules** out of your GraphQL server.
 
 - [Website](https://graphql-modules.com)
-- [Documentation](https://graphql-modules.com/docs/index)
+- [Documentation](https://graphql-modules.com/docs)
 
 ## Highlights
 
@@ -19,7 +19,7 @@
 
 ## Documentation
 
-Documentation is available at [graphql-modules.com](https://graphql-modules.com/docs/index).
+Documentation is available at [graphql-modules.com](https://graphql-modules.com/docs).
 
 ## Installation
 
@@ -41,7 +41,7 @@ Just take a look at the build status on Github Actions and find "Publish Canary"
 
 ## Usage
 
-More advanced usage at [graphql-modules.com](https://graphql-modules.com/docs/index)
+More advanced usage at [graphql-modules.com](https://graphql-modules.com/docs)
 
 ```js
 import { createModule, createApplication, gql } from 'graphql-modules';

--- a/packages/graphql-modules/CHANGELOG.md
+++ b/packages/graphql-modules/CHANGELOG.md
@@ -74,6 +74,6 @@
 ## 1.0.0
 
 Complete rewrite of GraphQL Modules based on lessons learned from using and maintaining v0 releases.
-The ["Introduction to GraphQL Modules"](https://graphql-modules.com/docs/index) page will help you understand the new version.
+The ["Introduction to GraphQL Modules"](https://graphql-modules.com/docs) page will help you understand the new version.
 
 For migration guide, please check ["Migration from v0.X"](https://graphql-modules.com/docs/recipes/migration) chapter in docs.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -32,7 +32,7 @@ module.exports = {
           position: 'left',
         },
         {
-          to: 'docs/index',
+          to: 'docs/',
           activeBasePath: 'docs',
           label: 'Documentation',
           position: 'right',

--- a/website/src/ui/home/contact-us.js
+++ b/website/src/ui/home/contact-us.js
@@ -11,8 +11,7 @@ export function ContactUs() {
       <h2 className="_kicker">Need Help?</h2>
       <h1 className="_title">We've Got You Covered!</h1>
       <div className="_subtitle">
-        Check out our <Link href="/docs/index">docs</Link>, open an issue
-        on our{' '}
+        Check out our <Link href="/docs">docs</Link>, open an issue on our{' '}
         <a href="https://github.com/Urigo/graphql-modules">GitHub repo</a> or
         simply contact us directly! We would love to help you with Apollo,
         GraphQL and GraphQL Modules and anything in between! We can help you get

--- a/website/src/ui/home/intro.js
+++ b/website/src/ui/home/intro.js
@@ -18,7 +18,7 @@ export function Intro(props) {
           your GraphQL server.
         </div>
         <Hyperlink></Hyperlink>
-        <Hyperlink href="/docs/index">
+        <Hyperlink href="/docs">
           <Button className="_start-button">Get started</Button>
         </Hyperlink>
       </div>


### PR DESCRIPTION
Regression since commit: ecd49ba442335c6941aa3a4bfffed6930981b79a

Most likely the new major of Docusaurus has a less permissive routing.


----

## Action items

- [ ] post release: reply to https://twitter.com/PatZawa/status/1484175463526322176