### PR TITLE
Replace createSchemaForApollo with createApolloExecutor in docs

### DIFF
--- a/examples/apollo-subscriptions/src/app/index.ts
+++ b/examples/apollo-subscriptions/src/app/index.ts
@@ -4,10 +4,5 @@ import { PostModule } from './post/post.module';
 
 export const graphqlApplication = createApplication({
   modules: [PostModule],
-  providers: [
-    {
-      provide: PubSub,
-      useValue: new PubSub(),
-    },
-  ],
+  providers: [PubSub],
 });

--- a/examples/apollo-subscriptions/src/index.ts
+++ b/examples/apollo-subscriptions/src/index.ts
@@ -2,26 +2,54 @@ import 'reflect-metadata';
 import express from 'express';
 import { createServer } from 'http';
 import { ApolloServer } from 'apollo-server-express';
+import { ApolloServerPluginDrainHttpServer } from 'apollo-server-core';
 import { graphqlApplication } from './app';
+import { WebSocketServer } from 'ws';
+import { useServer } from 'graphql-ws/lib/use/ws';
 
-const { createSchemaForApollo } = graphqlApplication;
-const schema = createSchemaForApollo();
+const { schema, createExecution, createSubscription, createApolloExecutor } =
+  graphqlApplication;
+
+const executor = createApolloExecutor();
+
+const app = express();
+const httpServer = createServer(app);
+// Creating the WebSocket subscription server
 
 const server = new ApolloServer({
   schema,
+  executor,
+  plugins: [
+    // Proper shutdown for the HTTP server.
+    ApolloServerPluginDrainHttpServer({ httpServer }),
+    // Proper shutdown for the WebSocket server.
+    {
+      async serverWillStart() {
+        return {
+          async drainServer() {
+            await serverCleanup.dispose();
+          },
+        };
+      },
+    },
+  ],
 });
 
-const app = express();
 server.applyMiddleware({ app });
 
-const httpServer = createServer(app);
-server.installSubscriptionHandlers(httpServer);
+const wsServer = new WebSocketServer({
+  server: httpServer,
+  path: server.graphqlPath,
+});
+
+const execute = createExecution();
+const subscribe = createSubscription();
+
+// Passing in an instance of a GraphQLSchema and
+// telling the WebSocketServer to start listening
+const serverCleanup = useServer({ schema, execute, subscribe }, wsServer);
 
 httpServer.listen({ port: 4000 }, () => {
   // tslint:disable-next-line: no-console
   console.info(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`);
-  // tslint:disable-next-line: no-console
-  console.info(
-    `🚀 Subsciription ready at ws://localhost:4000${server.subscriptionsPath}`
-  );
 });

--- a/examples/subscriptions/src/app/index.ts
+++ b/examples/subscriptions/src/app/index.ts
@@ -3,11 +3,6 @@ import { PubSub } from 'graphql-subscriptions';
 import { PostModule } from './post/post.module';
 
 export const app = createApplication({
-  providers: [
-    {
-      provide: PubSub,
-      useValue: new PubSub(),
-    },
-  ],
+  providers: [PubSub],
   modules: [PostModule],
 });

--- a/examples/subscriptions/src/index.ts
+++ b/examples/subscriptions/src/index.ts
@@ -1,13 +1,10 @@
 import 'reflect-metadata';
 import { createServer } from 'http';
-import { SubscriptionServer } from 'subscriptions-transport-ws';
+import { WebSocketServer } from 'ws';
+import { useServer } from 'graphql-ws/lib/use/ws';
 import { app } from './app';
 
 const WS_PORT = 5000;
-
-const schema = app.schema;
-const execute = app.createExecution();
-const subscribe = app.createSubscription();
 
 // Create WebSocket listener server
 const websocketServer = createServer((_request, response) => {
@@ -19,15 +16,20 @@ const websocketServer = createServer((_request, response) => {
 websocketServer.listen(WS_PORT, () => {
   console.log(`Live http://localhost:${WS_PORT}/graphql`);
 });
+const wsServer = new WebSocketServer({
+  port: 4000,
+  path: '/graphql',
+});
 
-SubscriptionServer.create(
+const schema = app.schema;
+const execute = app.createExecution();
+const subscribe = app.createSubscription();
+
+useServer(
   {
     schema,
     execute,
     subscribe,
   },
-  {
-    server: websocketServer,
-    path: '/graphql',
-  }
+  wsServer
 );

--- a/package.json
+++ b/package.json
@@ -56,16 +56,17 @@
     "globby": "11.1.0",
     "graphql": "16.5.0",
     "graphql-subscriptions": "2.0.0",
+    "graphql-ws": "5.8.2",
     "husky": "7.0.4",
     "jest": "27.5.1",
     "lint-staged": "13.0.1",
     "patch-package": "6.4.7",
     "prettier": "2.6.2",
     "reflect-metadata": "0.1.13",
-    "subscriptions-transport-ws": "0.11.0",
     "ts-jest": "27.1.5",
     "ts-node": "10.8.1",
-    "typescript": "4.7.3"
+    "typescript": "4.7.3",
+    "ws": "8.7.0"
   },
   "prettier": {
     "trailingComma": "es5",

--- a/website/docs/api.mdx
+++ b/website/docs/api.mdx
@@ -50,8 +50,7 @@ A return type of `createApplication` function.
   Important when using GraphQL Subscriptions.
 - `createExecution` - Creates a `execute` function that runs the execution phase of GraphQL.
   Important when using GraphQL Queries and Mutations.
-- `createSchemaForApollo` - Experimental
-- `createApolloExecutor` - Experimental
+- `createApolloExecutor` - Creates an `executor` for `ApolloServer`
 
 ## ApplicationConfig
 

--- a/website/docs/get-started.mdx
+++ b/website/docs/get-started.mdx
@@ -83,16 +83,18 @@ Your GraphQL `Application` exposes `createExecution` and `createSubscription` me
 <MDXTabs namespace={`get-started-libraries`}>
 <MDXTab label="Apollo Server">
 
-If you are using [Apollo-Server](https://github.com/apollographql/apollo-server), you can use `createSchemaForApollo` to get a schema that is adapted for this server, and integrates with it perfectly.
+If you are using [Apollo-Server](https://github.com/apollographql/apollo-server), you can use `createApolloExecutor` to get an executor that is adapted for this server, and integrates with it perfectly.
 
 ```typescript title="/src/server.ts"
 import { ApolloServer } from 'apollo-server'
 import { application } from './application'
 
-const schema = application.createSchemaForApollo()
+const executor = application.createApolloExecutor()
+const schema = application.schema
 
 const server = new ApolloServer({
-  schema
+  schema,
+  executor
 })
 
 server.listen().then(({ url }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4540,7 +4540,7 @@ babel-preset-jest@^27.5.1:
     babel-plugin-jest-hoist "^27.5.1"
     babel-preset-current-node-syntax "^1.0.0"
 
-backo2@1.0.2, backo2@^1.0.2:
+backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
   integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
@@ -6881,11 +6881,6 @@ etag@~1.8.1:
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-eventemitter3@^3.1.0:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
-  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
-
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -7780,6 +7775,11 @@ graphql-tag@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.11.0.tgz#1deb53a01c46a7eb401d6cb59dec86fa1cccbffd"
   integrity sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
+
+graphql-ws@5.8.2:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.8.2.tgz#800184b1addb20b3010dc06cb70877703a5fff20"
+  integrity sha512-hYo8kTGzxePFJtMGC7Y4cbypwifMphIJJ7n4TDcVUAfviRwQBnmZAbfZlC+XFwWDUaR7raEDQPxWctpccmE0JQ==
 
 graphql@16.5.0:
   version "16.5.0"
@@ -8759,7 +8759,7 @@ istanbul-reports@^3.1.3:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-iterall@^1.2.1, iterall@^1.3.0:
+iterall@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
@@ -13105,17 +13105,6 @@ stylis@4.0.13, stylis@^4.0.10, stylis@^4.0.6:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
   integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
 
-subscriptions-transport-ws@0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz#baf88f050cba51d52afe781de5e81b3c31f89883"
-  integrity sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==
-  dependencies:
-    backo2 "^1.0.2"
-    eventemitter3 "^3.1.0"
-    iterall "^1.2.1"
-    symbol-observable "^1.0.4"
-    ws "^5.2.0 || ^6.0.0 || ^7.0.0"
-
 sucrase@^3.20.3:
   version "3.20.3"
   resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.20.3.tgz#424f1e75b77f955724b06060f1ae708f5f0935cf"
@@ -13166,11 +13155,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
-
-symbol-observable@^1.0.4:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
-  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.4:
   version "3.2.4"
@@ -14297,6 +14281,11 @@ write-pkg@^4.0.0:
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
 
+ws@8.7.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.7.0.tgz#eaf9d874b433aa00c0e0d8752532444875db3957"
+  integrity sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==
+
 ws@^5.1.1:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.3.tgz#05541053414921bc29c63bee14b8b0dd50b07b3d"
@@ -14304,7 +14293,7 @@ ws@^5.1.1:
   dependencies:
     async-limiter "~1.0.0"
 
-"ws@^5.2.0 || ^6.0.0 || ^7.0.0", ws@^7.3.1, ws@^7.4.5:
+ws@^7.3.1, ws@^7.4.5:
   version "7.5.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.6.tgz#e59fc509fb15ddfb65487ee9765c5a51dec5fe7b"
   integrity sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==


### PR DESCRIPTION
GraphQL Modules need to control execution lifecycle so it generates custom execute and subscribe functions instead of graphql-js’s default ones.
Unfortunately Apollo Server doesn’t support custom execute and subscribe functions but instead you can provide executor function that does similar job but it doesn’t support subscriptions. We have introduced createApolloExecutor but it wasn’t enough for Apollo users that also use subscriptions. So we decided to use @graphql-tools/wrap which allows you to create a standalone schema with custom execution logic just like we need for GraphQL Modules. But it has some performance downsides.
After Apollo Server v3, they dropped builtin subscriptions implementation. Then I realized we don’t need to create wrapped schemas from now on.

_Side not about Apollo's `cacheControl`; You don’t  have “info.cacheControl” with the wrapped schema because internal resolution of that wrapped schema uses default graphql-js execution logic which doesn’t have it._ 

In the next major, we can drop it together with `@graphql-tools/wrap` dependency.