### PR TITLE
Make ExecutionContext opt-in

### DIFF
--- a/.changeset/tame-oranges-exercise.md
+++ b/.changeset/tame-oranges-exercise.md
@@ -1,0 +1,5 @@
+---
+'graphql-modules': major
+---
+
+Make ExecutionContext opt-in and graphql-modules not node specific

--- a/packages/graphql-modules/src/application/application.ts
+++ b/packages/graphql-modules/src/application/application.ts
@@ -19,6 +19,7 @@ import {
   instantiateSingletonProviders,
 } from './di';
 import { createContextBuilder } from './context';
+import { enableExecutionContext } from './execution-context';
 import { executionCreator } from './execution';
 import { subscriptionCreator } from './subscription';
 import { apolloSchemaCreator, apolloExecutorCreator } from './apollo';
@@ -45,6 +46,7 @@ export interface InternalAppContext {
  *
  * ```typescript
  * import { createApplication } from 'graphql-modules';
+ * import { createHook, executionAsyncId } from 'async_hooks';
  * import { usersModule } from './users';
  * import { postsModule } from './posts';
  * import { commentsModule } from './comments';
@@ -54,7 +56,8 @@ export interface InternalAppContext {
  *     usersModule,
  *     postsModule,
  *     commentsModule
- *   ]
+ *   ],
+ *   executionContext: { createHook, executionAsyncId },
  * })
  * ```
  */
@@ -63,6 +66,11 @@ export function createApplication(
 ): Application {
   function applicationFactory(cfg?: ApplicationConfig): Application {
     const config = cfg || applicationConfig;
+
+    if (config.executionContext) {
+      enableExecutionContext(config.executionContext);
+    }
+
     const providers =
       config.providers && typeof config.providers === 'function'
         ? config.providers()

--- a/packages/graphql-modules/src/application/execution-context.ts
+++ b/packages/graphql-modules/src/application/execution-context.ts
@@ -1,4 +1,10 @@
-import { createHook, executionAsyncId } from 'async_hooks';
+export interface ExecutionContextConfig {
+  executionAsyncId: () => number;
+  createHook(config: {
+    init(asyncId: number, _: string, triggerAsyncId: number): void;
+    destroy(asyncId: number): void;
+  }): void;
+}
 
 export interface ExecutionContextPicker {
   getModuleContext(moduleId: string): GraphQLModules.ModuleContext;
@@ -8,26 +14,8 @@ export interface ExecutionContextPicker {
 const executionContextStore = new Map<number, ExecutionContextPicker>();
 const executionContextDependencyStore = new Map<number, Set<number>>();
 
-const executionContextHook = createHook({
-  init(asyncId, _, triggerAsyncId) {
-    // Store same context data for child async resources
-    const ctx = executionContextStore.get(triggerAsyncId);
-    if (ctx) {
-      const dependencies =
-        executionContextDependencyStore.get(triggerAsyncId) ??
-        executionContextDependencyStore
-          .set(triggerAsyncId, new Set())
-          .get(triggerAsyncId)!;
-      dependencies.add(asyncId);
-      executionContextStore.set(asyncId, ctx);
-    }
-  },
-  destroy(asyncId) {
-    if (executionContextStore.has(asyncId)) {
-      executionContextStore.delete(asyncId);
-    }
-  },
-});
+let executionContextHook = null;
+let executionAsyncId: () => number = () => 0;
 
 function destroyContextAndItsChildren(id: number) {
   if (executionContextStore.has(id)) {
@@ -44,12 +32,20 @@ function destroyContextAndItsChildren(id: number) {
   }
 }
 
+let executionContextEnabled = false;
+
 export const executionContext: {
   create(picker: ExecutionContextPicker): () => void;
   getModuleContext: ExecutionContextPicker['getModuleContext'];
   getApplicationContext: ExecutionContextPicker['getApplicationContext'];
 } = {
   create(picker) {
+    if (!executionContextEnabled) {
+      return function destroyContextNoop() {
+        // noop
+      };
+    }
+
     const id = executionAsyncId();
     executionContextStore.set(id, picker);
     return function destroyContext() {
@@ -57,20 +53,51 @@ export const executionContext: {
     };
   },
   getModuleContext(moduleId) {
+    assertExecutionContext();
+
     const picker = executionContextStore.get(executionAsyncId())!;
     return picker.getModuleContext(moduleId);
   },
   getApplicationContext() {
+    assertExecutionContext();
+
     const picker = executionContextStore.get(executionAsyncId())!;
     return picker.getApplicationContext();
   },
 };
 
-let executionContextEnabled = false;
-
-export function enableExecutionContext() {
+export function enableExecutionContext(config: ExecutionContextConfig) {
   if (!executionContextEnabled) {
-    executionContextHook.enable();
+    executionContextHook = config.createHook({
+      init(asyncId, _, triggerAsyncId) {
+        // Store same context data for child async resources
+        const ctx = executionContextStore.get(triggerAsyncId);
+        if (ctx) {
+          const dependencies =
+            executionContextDependencyStore.get(triggerAsyncId) ??
+            executionContextDependencyStore
+              .set(triggerAsyncId, new Set())
+              .get(triggerAsyncId)!;
+          dependencies.add(asyncId);
+          executionContextStore.set(asyncId, ctx);
+        }
+      },
+      destroy(asyncId) {
+        if (executionContextStore.has(asyncId)) {
+          executionContextStore.delete(asyncId);
+        }
+      },
+    });
+    executionAsyncId = config.executionAsyncId;
+    executionContextEnabled = true;
+  }
+}
+
+export function assertExecutionContext(): void | never {
+  if (!executionContextEnabled) {
+    throw new Error(
+      'Execution Context is not enabled. Please set `executionContext` option in `createApplication`'
+    );
   }
 }
 

--- a/packages/graphql-modules/src/application/types.ts
+++ b/packages/graphql-modules/src/application/types.ts
@@ -8,6 +8,7 @@ import {
 import type { Provider, Injector } from '../di';
 import type { Resolvers, Module, MockedModule } from '../module/types';
 import type { MiddlewareMap } from '../shared/middleware';
+import type { ExecutionContextConfig } from './execution-context';
 import type { ApolloRequestContext } from './apollo';
 import type { Single } from '../shared/types';
 import type { InternalAppContext } from './application';
@@ -139,4 +140,20 @@ export interface ApplicationConfig {
     typeDefs: DocumentNode[];
     resolvers: Record<string, any>[];
   }): GraphQLSchema;
+
+  /**
+   * Enables ExecutionContext
+   *
+   * @example
+   *
+   * ```typescript
+   * import { createHook, executionAsyncId } from 'async_hooks';
+   *
+   * const app = createApplication({
+   *  modules: [],
+   *  executionContext: { createHook, executionAsyncId }
+   * });
+   * ```
+   */
+  executionContext?: ExecutionContextConfig;
 }

--- a/packages/graphql-modules/src/di/decorators.ts
+++ b/packages/graphql-modules/src/di/decorators.ts
@@ -6,7 +6,7 @@ import {
   ensureInjectableMetadata,
 } from './metadata';
 import { Injector } from './injector';
-import { enableExecutionContext } from '../application/execution-context';
+import { assertExecutionContext } from '../application/execution-context';
 
 function ensureReflect() {
   if (!(Reflect && Reflect.getOwnMetadata)) {
@@ -17,7 +17,6 @@ function ensureReflect() {
 export function Injectable(options?: ProviderOptions): ClassDecorator {
   return (target) => {
     ensureReflect();
-    enableExecutionContext();
 
     const params: Type<any>[] = (
       Reflect.getMetadata('design:paramtypes', target) || []

--- a/packages/graphql-modules/tests/di-hooks.spec.ts
+++ b/packages/graphql-modules/tests/di-hooks.spec.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata';
+import { createHook, executionAsyncId } from 'async_hooks';
 import {
   createApplication,
   createModule,
@@ -79,6 +80,7 @@ test('OnDestroy hook', async () => {
 
   const app = createApplication({
     modules: [postsModule],
+    executionContext: { createHook, executionAsyncId },
   });
 
   const createContext = () => ({ request: {}, response: {} });

--- a/packages/graphql-modules/tests/di-providers.spec.ts
+++ b/packages/graphql-modules/tests/di-providers.spec.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata';
+import { createHook, executionAsyncId } from 'async_hooks';
 import {
   createApplication,
   createModule,
@@ -301,6 +302,10 @@ test('useFactory with dependencies', async () => {
 
   const app = createApplication({
     modules: [postsModule],
+    executionContext: {
+      createHook,
+      executionAsyncId,
+    },
   });
 
   const createContext = () => ({ request: {}, response: {} });

--- a/packages/graphql-modules/tests/execution-context.spec.ts
+++ b/packages/graphql-modules/tests/execution-context.spec.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata';
+import { createHook, executionAsyncId } from 'async_hooks';
 import {
   createApplication,
   createModule,
@@ -95,6 +96,7 @@ test('ExecutionContext on module level provider', async () => {
 
   const app = createApplication({
     modules: [postsModule],
+    executionContext: { createHook, executionAsyncId },
   });
 
   const createContext = () => ({ request: {}, response: {} });
@@ -209,6 +211,7 @@ test('ExecutionContext on application level provider', async () => {
   const app = createApplication({
     modules: [postsModule],
     providers: [Posts, PostsConnection],
+    executionContext: { createHook, executionAsyncId },
   });
 
   const createContext = () => ({ request: {}, response: {} });
@@ -304,6 +307,7 @@ test('ExecutionContext on module level global provider', async () => {
 
   const app = createApplication({
     modules: [postsModule],
+    executionContext: { createHook, executionAsyncId },
   });
 
   const createContext = () => ({ request: {}, response: {} });
@@ -389,6 +393,7 @@ test('ExecutionContext on application level global provider', async () => {
   const app = createApplication({
     modules: [postsModule],
     providers: [Posts],
+    executionContext: { createHook, executionAsyncId },
   });
 
   const createContext = () => ({ noop() {} });
@@ -488,6 +493,7 @@ test('accessing a singleton provider with execution context in another singleton
         useValue: expectedName,
       },
     ],
+    executionContext: { createHook, executionAsyncId },
   });
 
   const result = await testkit.execute(app, {

--- a/website/src/pages/docs/advanced/execution-context.mdx
+++ b/website/src/pages/docs/advanced/execution-context.mdx
@@ -4,13 +4,30 @@ import { Callout } from '@theguild/components'
 
 Execution Context means the context of the execution of GraphQL Operation. It's related to Dependency Injection, especially Singletons and represents the context object created by your GraphQL server.
 
+## Enabling Execution Context
+
+To enable Execution Context, you need to pass `createHook` and `executionAsyncId` functions from the `async_hooks` module in `createApplication`.
+
+```ts
+import { createApplication } from 'graphql-modules';
+import { createHook, executionAsyncId } from 'async_hooks';
+
+const app = createApplication({
+  modules: [/* ... */],
+  executionContext: {
+    createHook,
+    executionAsyncId,
+  }
+});
+```
+
 Why "especially useful in `Singleton`s"?
 
 As you know from ["Introduction to Dependency Injection"](../di/introduction) chapter, `Singleton`s can't directly access Operation scoped services, meaning they probably can't also directly access the context object created per each operation. Directly.
 
 Thanks to `@ExecutionContext` decorator, every `Singleton` provider gets access to the GraphQL Context and the Operation scoped Injector.
 
-Take a look at the example below:
+## Example
 
 ```ts
 import { Injectable, ExecutionContext } from 'graphql-modules'
@@ -43,6 +60,5 @@ It also means you gain a lot in terms of performance because the `Data` class is
   `@ExecutionContext` impacts the performance, depending on your Node version
   (execution context uses `async_hooks` module).
 
-  GraphQL Modules is smart enough to enable `async_hooks` only when
-  `@ExecutionContext` is used.
+  `@ExecutionContext` is available only for Node environments.
 </Callout>


### PR DESCRIPTION
Adds `executionContext: { createHook, executionAsyncId }` to `createApplication`, yeah breaking change.

Closes #1697