### PR TITLE
Update package json exports to include type definitions

### DIFF
--- a/.changeset/tough-papayas-hammer.md
+++ b/.changeset/tough-papayas-hammer.md
@@ -1,0 +1,5 @@
+---
+'graphql-modules': patch
+---
+
+Fix missing attributes in package.json (as preparation for TS 5.0)

--- a/packages/graphql-modules/package.json
+++ b/packages/graphql-modules/package.json
@@ -17,11 +17,13 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "types": "./index.d.ts"
     },
     "./*": {
       "require": "./dist/*.js",
-      "import": "./dist/*.mjs"
+      "import": "./dist/*.mjs",
+      "types": "./*.d.ts"
     }
   },
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Related to #2323 

## Description

[Typescript 5.0 is in beta](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#moduleresolution-bundler), and it adds a couple new compiler options.

If you want to use the new moduleResolution mode "bundler" or compiler option "resolvePackageJsonExports", Typescript will ignore the top-level "types" field in your package.json and only look for types inside package.json "exports".

See: https://github.com/microsoft/TypeScript/issues/52363

That means, types need to be directly pointed at in package.json exports.

Partially addresses #2323 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests and linter rules pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
