### PR TITLE
feat: support custom fieldResolver in createSchemaForApollo

### DIFF
--- a/packages/graphql-modules/src/application/apollo.ts
+++ b/packages/graphql-modules/src/application/apollo.ts
@@ -1,5 +1,5 @@
 import { wrapSchema } from '@graphql-tools/wrap';
-import { DocumentNode, execute, GraphQLSchema } from 'graphql';
+import { DocumentNode, execute, ExecutionArgs, GraphQLSchema } from 'graphql';
 import { uniqueId } from '../shared/utils';
 import { InternalAppContext } from './application';
 import { ExecutionContextBuilder } from './context';
@@ -47,7 +47,9 @@ export function apolloSchemaCreator({
   contextBuilder: ExecutionContextBuilder;
   schema: GraphQLSchema;
 }) {
-  const createApolloSchema = () => {
+  const createApolloSchema = ({
+    fieldResolver,
+  }: Pick<ExecutionArgs, 'fieldResolver'> = {}) => {
     const sessions: Record<
       string,
       {
@@ -114,6 +116,7 @@ export function apolloSchemaCreator({
                 variableValues: input.variables as any,
                 rootValue: input.rootValue,
                 operationName: input.operationName,
+                fieldResolver,
               }) as any
           )
           .finally(destroy);

--- a/packages/graphql-modules/src/application/types.ts
+++ b/packages/graphql-modules/src/application/types.ts
@@ -4,6 +4,7 @@ import {
   DocumentNode,
   GraphQLSchema,
   ExecutionResult,
+  ExecutionArgs,
 } from 'graphql';
 import type { Provider, Injector } from '../di';
 import type { Resolvers, Module, MockedModule } from '../module/types';
@@ -70,7 +71,9 @@ export interface Application {
   /**
    * @deprecated Use `createApolloExecutor`, `createExecution` and `createSubscription` methods instead.
    */
-  createSchemaForApollo(): GraphQLSchema;
+  createSchemaForApollo(
+    options?: Pick<ExecutionArgs, 'fieldResolver'>
+  ): GraphQLSchema;
   /**
    * Experimental
    */


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Because of the way how `createSchemaForApollo` works if you want to override Apollo Server's default field resolvers you can't do so in Apollo Schema options

Fixes [(issue)](https://github.com/Urigo/graphql-modules/issues/2326)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

## How Has This Been Tested?

My use case is very simple: a legacy application that mixes database entities managed directly by the ORM with GraphQL helpers that aim to reduce the load down the graph. Whenever makes sense to return these helpers the return type is an object/array with the entity and the helpers, otherwise it's just the Entity. The custom fieldResolver function looks at the type: if it's an entity it returns the default fieldResolver function, otherwise it looks for the fieldName in the `info` object and decides if to call the default fieldResolver function on the entity or on the helpers.

```ts
new ApolloServer<ApolloContext>({
  schema: createApp({ orm, pool, bypass, sort }).createSchemaForApollo({
    // Handle [entity, helper] models
    fieldResolver: (source, args, context, info) =>
      defaultFieldResolver(
        source instanceof Array
          ? (source?.[0]?.[info.fieldName] != null && source[0]) ??
              (source?.[1]?.[info.fieldName] != null && source[1]) ??
              source
          : source,
        args,
        context,
        info
      ),
  }),
  [...]
});
```

That's just a simple `fieldResolver` function to test if it works properly.

**Test Environment**:

- OS: Gentoo Linux ppc64le
- `graphql-modules`: 2.1.1
- NodeJS: v18.15.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I didn't create any tests nor updated the documentation. If you think this is worth adding I will do so.
At this point we might just expose as well `typeResolver` and `subscribeFieldResolver`.
