### PR TITLE
fix: inject and optional decorators should allow key to be undefined

### DIFF
--- a/.changeset/lazy-bulldogs-cry.md
+++ b/.changeset/lazy-bulldogs-cry.md
@@ -1,0 +1,5 @@
+---
+'graphql-modules': patch
+---
+
+TypeScript 5 support for the Inject and Optional decorators

--- a/packages/graphql-modules/src/di/decorators.ts
+++ b/packages/graphql-modules/src/di/decorators.ts
@@ -51,6 +51,13 @@ export function Injectable(options?: ProviderOptions): ClassDecorator {
   };
 }
 
+// https://github.com/microsoft/TypeScript/issues/52435
+type ParameterDecorator = (
+  target: Object,
+  propertyKey: string | symbol | undefined,
+  parameterIndex: number
+) => void;
+
 export function Optional(): ParameterDecorator {
   return (target, _, index) => {
     ensureReflect();


### PR DESCRIPTION
## Description

Typescript 5 has [tighter parameter decorator checking with --experimentalDecorators](https://github.com/microsoft/TypeScript/issues/52435).
That means [constructor parameter decorators should allow undefined as the type of key](https://github.com/nestjs/nest/issues/10959).

Fixes [# (issue)](https://github.com/Urigo/graphql-modules/issues/2328)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

## How Has This Been Tested?

I've tested patched graphql-modules in a project that makes use of TS5 and the `Inject` decorator.

**Test Environment**:

- OS: Gentoo Linux ppc64le
- `graphql-modules`: 2.1.1
- NodeJS: v18.15.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
