### PR TITLE
Support nested execution contexts and contexts created in a separate async execution within the same stack

### DIFF
--- a/packages/graphql-modules/tests/execution-context.spec.ts
+++ b/packages/graphql-modules/tests/execution-context.spec.ts
@@ -544,11 +544,14 @@ it('should provide context in nested async execution', async () => {
       },
     });
     resolve();
-  }).then(() => {
-    expect(executionContext.getApplicationContext()).toBe('app');
-    expect(executionContext.getModuleContext('')).toBe('mod');
-  });
-  destroy();
+  })
+    .then(() => {
+      expect(executionContext.getApplicationContext()).toBe('app');
+      expect(executionContext.getModuleContext('')).toBe('mod');
+    })
+    .finally(() => {
+      destroy();
+    });
 });
 
 it('should provide nested contexts', async () => {

--- a/packages/graphql-modules/tests/execution-context.spec.ts
+++ b/packages/graphql-modules/tests/execution-context.spec.ts
@@ -530,6 +530,27 @@ it('should provide context when created in separate async execution within same 
   destroy();
 });
 
+it('should provide context in nested async execution', async () => {
+  let destroy = () => {
+    // noop
+  };
+  await new Promise<void>((resolve) => {
+    destroy = executionContext.create({
+      getApplicationContext() {
+        return 'app' as any;
+      },
+      getModuleContext() {
+        return 'mod' as any;
+      },
+    });
+    resolve();
+  }).then(() => {
+    expect(executionContext.getApplicationContext()).toBe('app');
+    expect(executionContext.getModuleContext('')).toBe('mod');
+  });
+  destroy();
+});
+
 it('should provide nested contexts', async () => {
   const createPicker = (i: number) => ({
     getApplicationContext() {


### PR DESCRIPTION
Closes https://github.com/Urigo/graphql-modules/issues/2227

Often found behaviour, especially when using [`@envelop/graphql-modules`](https://github.com/n1ru4l/envelop/blob/main/packages/plugins/graphql-modules/README.md):

1. Create the operation controller in one plugin hook and use its context in another hook (different async execution, but same stack; for ex. `onContextBuilding` creates, `onExecute` uses)
2. Create the operation controller and use its context in a nested async execution
3. Create nested operation controllers. If the user does invokes `createOperationController`, they are creating a nested context since the plugin itself [already created an operation controller]](https://github.com/n1ru4l/envelop/blob/main/packages/plugins/graphql-modules/src/index.ts#L19C1-L22)

_Note that creating an operation controller creates an execution context._

The current implementation of execution context handler has 2 work modes: using [`AsyncLocalStorage.enterWith`](https://nodejs.org/api/async_context.html#asynclocalstorageenterwithstore) (Node v14+) or [`async_hooks.createHook`](https://nodejs.org/api/async_hooks.html#async_hookscreatehookcallbacks) (fallback).

When using `AsyncLocalStorage.enterWith`, 1. and 2. will work because it binds to the stack. However, 3. will create wonky behaviour (probably related to https://github.com/nodejs/node/issues/45848 and https://github.com/nodejs/help/issues/3041). Node doesn't recommend using `AsyncLocalStorage.enterWith` because if its "magical" behaviour, reduced visibility and harder debugging (see comments from the related issues above). Additionally, even though `AsyncLocalStorage.enterWith` was introduced with Node v14, it's still considered unstable and Node's team doesn't want to promote it to stable because of the aforementioned reasons (see https://github.com/nodejs/node/issues/35286). AsyncLocalStorage was introduced in #2395.

On the other hand, when using `async_hooks.createHook`, both 1., 2. and 3. will fail. Where 1. and 2. is much more important (because of [`@envelop/graphql-modules`](https://github.com/n1ru4l/envelop/blob/main/packages/plugins/graphql-modules/README.md)). The reason it fails is because of how the createHook's init is implemented - it only considers nested async executions, not parallel ones within the same stack. 

### TODO

- [ ] Should nested operation controllers even be allowed?