### PR TITLE
fix: use graphql utilties to more reliable check for class types 

### DIFF
--- a/packages/graphql-modules/src/module/resolvers.ts
+++ b/packages/graphql-modules/src/module/resolvers.ts
@@ -5,6 +5,7 @@ import {
   defaultFieldResolver,
   FieldNode,
   GraphQLResolveInfo,
+  isScalarType,
 } from 'graphql';
 import { Resolvers, ModuleConfig } from './types';
 import { ModuleMetadata } from './metadata';
@@ -508,7 +509,7 @@ function isResolveOptions(value: any): value is ResolveOptions {
 }
 
 function isScalarResolver(obj: any): obj is GraphQLScalarType {
-  return obj instanceof GraphQLScalarType;
+  return isScalarType(obj);
 }
 
 interface EnumResolver {

--- a/packages/graphql-modules/src/shared/utils.ts
+++ b/packages/graphql-modules/src/shared/utils.ts
@@ -1,4 +1,4 @@
-import { GraphQLSchema } from 'graphql';
+import { GraphQLSchema, isSchema } from 'graphql';
 
 export function flatten<T>(arr: T[]): T extends (infer A)[] ? A[] : T[] {
   return Array.prototype.concat(...arr) as any;
@@ -105,7 +105,7 @@ export function uniqueId(isNotUsed: (id: string) => boolean) {
 }
 
 export function isNotSchema<T>(obj: any): obj is T {
-  return obj instanceof GraphQLSchema === false;
+  return !isSchema(obj);
 }
 
 export function merge<S extends object, T extends object>(


### PR DESCRIPTION

## Description

It is possible for multiple versions of the `graphql` module to exist which causes the instanceof checks to fail.   This PR uses the utilites from graphql to check instead, which under the covers uses string compare

Fixes # 2477

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?
Ran the tests.   

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
